### PR TITLE
Add source maps in webpack configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,5 +15,6 @@
         "transform-react-remove-prop-types"
       ]
     }
-  }
+  },
+  "sourceMaps": true
 }

--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,5 @@
         "transform-react-remove-prop-types"
       ]
     }
-  },
-  "sourceMaps": true
+  }
 }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -11,14 +11,7 @@ const build = process.env.BUILD_NUMBER || 'SNAPSHOT'
 
 const config = require('./src/config.json')
 
-let whitelist
-
-if (nodeEnv === 'development') {
-  whitelist = config.developmentWhitelist
-} else {
-  whitelist = config.productionWhitelist
-}
-
+const whitelist = config.developmentWhitelist
 
 const gnosisDbUrl =
   process.env.GNOSISDB_URL || `${config.gnosisdb.protocol}://${config.gnosisdb.host}:${config.gnosisdb.port}`
@@ -29,7 +22,7 @@ const ethereumUrl =
 module.exports = {
   context: path.join(__dirname, 'src'),
   entry: ['react-hot-loader/patch', 'bootstrap-loader', 'index.js'],
-  devtool: 'eval',
+  devtool: 'source-map',
   output: {
     publicPath: '/',
     path: `${__dirname}/dist`,

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -22,7 +22,7 @@ const ethereumUrl =
 module.exports = {
   context: path.join(__dirname, 'src'),
   entry: ['react-hot-loader/patch', 'bootstrap-loader', 'index.js'],
-  devtool: 'source-map',
+  devtool: 'eval-source-map',
   output: {
     publicPath: '/',
     path: `${__dirname}/dist`,

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -12,13 +12,7 @@ const build = process.env.BUILD_NUMBER || 'SNAPSHOT'
 
 const config = require('./src/config.json')
 
-let whitelist
-
-if (nodeEnv === 'development') {
-  whitelist = config.developmentWhitelist
-} else {
-  whitelist = config.productionWhitelist
-}
+const whitelist = config.productionWhitelist
 
 const gnosisDbUrl =
   process.env.GNOSISDB_URL || `${config.gnosisdb.protocol}://${config.gnosisdb.host}:${config.gnosisdb.port}`


### PR DESCRIPTION
DESCRIPTION
This PRs introduces source-maps for being used with Chrome DevTools only when developing.

TESTS DONE
I have tested the app running in bash
```
NODE_ENV=development npm start
NODE_ENV=production npm start
```

Checked both versions run the correct scripts and loaded the app.