### PR TITLE
Bug PM-107: Lost transactions stuck in running

### DIFF
--- a/src/components/Transactions/index.js
+++ b/src/components/Transactions/index.js
@@ -13,6 +13,7 @@ const completionMessages = {
   [TRANSACTION_COMPLETE_STATUS.NO_ERROR]: 'Transaction finished successfully',
   [TRANSACTION_COMPLETE_STATUS.ERROR]: 'Transaction did not finish, errors occured',
   [TRANSACTION_COMPLETE_STATUS.TIMEOUT]: 'Transaction timed out',
+  [TRANSACTION_COMPLETE_STATUS.LOST]: 'Because of a page reload, we lost the status of this Transaction',
 }
 
 const ProgressIndicator = ({ completed, completionStatus, progress }) => {

--- a/src/components/Transactions/index.js
+++ b/src/components/Transactions/index.js
@@ -24,13 +24,13 @@ const ProgressIndicator = ({ completed, completionStatus, progress }) => {
           <div className="icon icon--checkmark" />
         </div>
       )
-    } else {
-      return (
-        <div className="transaction__icon">
-          <div className="icon icon--error" />
-        </div>
-      )
     }
+
+    return (
+      <div className="transaction__icon">
+        <div className="icon icon--error" />
+      </div>
+    )
   }
 
   return (

--- a/src/reducers/transactions.js
+++ b/src/reducers/transactions.js
@@ -1,4 +1,7 @@
 import { handleActions } from 'redux-actions'
+import { get } from 'lodash'
+
+const LOAD_LOCALSTORAGE = 'LOAD_LOCALSTORAGE'
 
 import {
   TRANSACTION_STATUS,
@@ -75,6 +78,30 @@ const reducer = handleActions({
     ...state,
     visible: false,
   }),
+  [LOAD_LOCALSTORAGE]: (state, action) => {
+    const newState = {
+      ...state,
+      log: {},
+    }
+
+    const savedLogs = get(action, 'payload.transactions.log', {})
+    const logs = Object.keys(savedLogs)
+      .forEach((id) => {
+        const log = savedLogs[id]
+
+        if (log.completed) {
+          newState.log[id] = log
+        } else {
+          newState.log[id] = {
+            ...log,
+            completed: true,
+            completionStatus: 'LOST',
+          }
+        }
+      })
+
+    return newState
+  },
 }, { log: {}, visible: false })
 
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -46,6 +46,7 @@ export const TRANSACTION_COMPLETE_STATUS = {
   NO_ERROR: 'NO_ERROR',
   ERROR: 'ERROR',
   TIMEOUT: 'TIMEOUT',
+  LOST: 'LOST',
 }
 
 export const GAS_COST = {


### PR DESCRIPTION
Lost Transactions are transactions that were "running" but then got lost due to a page reload. If this happens, we now show a message for the user like this:
![image](https://user-images.githubusercontent.com/969493/32604221-315e9688-c54d-11e7-919a-e8af0b52e099.png)
