### PR TITLE
PM-154 Reject transactions with more 5% diff in prices

### DIFF
--- a/src/components/OutcomePriceChanged/index.js
+++ b/src/components/OutcomePriceChanged/index.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import '../TransactionsExplanation/TransactionExplanation.less'
+
+const OutcomePriceChanged = ({ closeModal }) => (
+  <div className="transactionsExplanation">
+    <a className="transactionsExplanation__close" href="javascript:void(0);" onClick={() => closeModal()} />
+    <h3>The price of the outcome has changed</h3>
+  </div>
+)
+
+OutcomePriceChanged.propTypes = {
+  closeModal: PropTypes.func,
+}
+
+export default OutcomePriceChanged

--- a/src/components/OutcomePriceChanged/index.js
+++ b/src/components/OutcomePriceChanged/index.js
@@ -5,7 +5,9 @@ import '../TransactionsExplanation/TransactionExplanation.less'
 const OutcomePriceChanged = ({ closeModal }) => (
   <div className="transactionsExplanation">
     <a className="transactionsExplanation__close" href="javascript:void(0);" onClick={() => closeModal()} />
-    <h3>The price of the outcome has changed</h3>
+    <h3>The transaction could not be processed because the trading price changed.<br />
+        Please check the new price and try again.
+    </h3>
   </div>
 )
 

--- a/src/config.json
+++ b/src/config.json
@@ -18,14 +18,14 @@
 
  },
  "gnosisdb": {
-   "protocol": "https",
-   "host": "gnosisdb-kovan.gnosis.pm",
-   "port": ""
- },
- "ethereum": {
-   "protocol": "https",
-   "host": "kovan.infura.io",
-   "port": ""
- },
+    "protocol": "http",
+    "host": "localhost",
+    "port": 8000
+  },
+  "ethereum": {
+    "protocol": "http",
+    "host": "localhost",
+    "port": 8545
+  },
  "fetchMarketTimeInterval": 15000
 }

--- a/src/containers/ModalOutcomePriceChanged/index.js
+++ b/src/containers/ModalOutcomePriceChanged/index.js
@@ -1,0 +1,3 @@
+import OutcomePriceChanged from 'components/OutcomePriceChanged'
+
+export default OutcomePriceChanged

--- a/src/containers/modals.js
+++ b/src/containers/modals.js
@@ -1,4 +1,5 @@
 export ModalMarketProgress from 'containers/ModalMarketProgress'
 export ModalConnectWallet from 'containers/ModalConnectWallet'
 export ModalNetworkCheck from 'containers/ModalNetworkCheck'
+export ModalOutcomePriceChanged from 'containers/ModalOutcomePriceChanged'
 export ModalTransactionsExplanation from 'containers/ModalTransactionsExplanation'

--- a/src/utils/marginPrice.js
+++ b/src/utils/marginPrice.js
@@ -1,0 +1,16 @@
+import Decimal from 'decimal.js'
+
+const allowedRangePrice = (oldP, newP) => {
+  const oldPrice = new Decimal(oldP)
+  const newPrice = new Decimal(newP)
+
+  // We calculate the 5% of the latest price applying 18 decimals round up
+  const allowance = new Decimal(newPrice).mul(5).div(100).toDP(18, Decimal.ROUND_UP)
+
+  // Calculate the abs difference between prices
+  const diff = new Decimal(newPrice).sub(oldPrice).absoluteValue()
+
+  return diff.lte(allowance)  // return true if diff between prices is lower than 5 percent
+}
+
+export default allowedRangePrice

--- a/src/utils/marginPrice.spec.js
+++ b/src/utils/marginPrice.spec.js
@@ -1,0 +1,45 @@
+import allowedRangePrice from './marginPrice'
+
+describe('Margin Price Calculation', () => {
+  test('it should be in range when same outcome price', () => {
+    const oldPrice = '0.3333333333333'
+    const newPrice = '0.3333333333333'
+
+    expect(allowedRangePrice(oldPrice, newPrice)).toEqual(true)
+  })
+
+  test('it should be in range when the new price is the minimum', () => {
+    const oldPrice = '0.000000000000000002'
+    const newPrice = '0.000000000000000001'
+
+    expect(allowedRangePrice(oldPrice, newPrice)).toEqual(true)
+  })
+
+  test('it should be in range when the new price is the maximum', () => {
+    const oldPrice = '0.949999999999999999'
+    const newPrice = '0.999999999999999999'
+
+    expect(allowedRangePrice(oldPrice, newPrice)).toEqual(true)
+  })
+
+  test('it should NOT be in range when the new price is the minimum and the old one is higher than 5% allowed', () => {
+    const oldPrice = '0.000000000000000003'
+    const newPrice = '0.000000000000000001'
+
+    expect(allowedRangePrice(oldPrice, newPrice)).toEqual(false)
+  })
+
+  test('it should NOT be in range when an obvious difference of 5% is set', () => {
+    const oldPrice = '0.4566'
+    const newPrice = '0.6745'
+
+    expect(allowedRangePrice(oldPrice, newPrice)).toEqual(false)
+  })
+
+  test('it should NOT be in range when the new price is the maximum and the old one is just exactly 5% of the max', () => {
+    const oldPrice = '0.949999999999999998'
+    const newPrice = '0.999999999999999999'
+
+    expect(allowedRangePrice(oldPrice, newPrice)).toEqual(false)
+  })
+})


### PR DESCRIPTION
**Due Diligence**
- [ ] Affects database
- [ ] Breaking change
- [x] Tests //Storybook components
- [ ] Documentation

**Description**
This PR reject transactions when buying tokens if the difference is higher than the 5%. Please double check the ```allowedRangePrice``` function and tests.