### PR TITLE
Feature PM-212 Replace 'bet' with 'trade'

### DIFF
--- a/src/components/MarketBuySharesForm/index.js
+++ b/src/components/MarketBuySharesForm/index.js
@@ -142,7 +142,7 @@ class MarketBuySharesForm extends Component {
       <div className="col-md-7">
         <div className="row">
           <div className="col-md-12">
-            <h2 className="marketBuyHeading">Your Bet</h2>
+            <h2 className="marketBuyHeading">Your Trade</h2>
           </div>
         </div>
         <div className="row">
@@ -234,7 +234,7 @@ class MarketBuySharesForm extends Component {
           <div className="col-md-6">
             <div className="row">
               <div className="col-md-12">
-                <h2 className="marketBuyHeading">Your Bet</h2>
+                <h2 className="marketBuyHeading">Your Trade</h2>
               </div>
             </div>
             <div className="row">

--- a/src/components/MarketShortSellForm/index.js
+++ b/src/components/MarketShortSellForm/index.js
@@ -20,7 +20,6 @@ import './marketShortSellForm.less'
 import '../MarketBuySharesForm/marketBuySharesForm.less'
 
 class MarketShortSellForm extends Component {
-
   getMaximumReturn(collateralTokenCount, profit) {
     if (!isNaN(parseFloat(collateralTokenCount)) && !isNaN(profit)
         && new Decimal(collateralTokenCount).gt(0) && new Decimal(profit).gte(0)) {
@@ -80,27 +79,26 @@ class MarketShortSellForm extends Component {
     if (!isNaN(parseFloat(selectedShortSellOutcome))) {
       // if (event.type === OUTCOME_TYPES.CATEGORICAL) {
       renderedOutcomes = eventDescription.outcomes
-      .filter((outcome, index) => index !== parseFloat(selectedShortSellOutcome))
+        .filter((outcome, index) => index !== parseFloat(selectedShortSellOutcome))
     }
     // Remove the current selected outcome from color_scheme, this allows us to
     // show the right colors for the unselected outcomes
     const colorScheme = Object.assign([], COLOR_SCHEME_DEFAULT)
     colorScheme.splice(selectedShortSellOutcome, 1)
 
-    return renderedOutcomes.map(
-      (outcome, index) =>
-        (
-          <div key={index} className="row">
-            <div
-              className={'entry__color col-md-4'} style={{ backgroundColor: colorScheme[index] }}
-            />
-            <div className="col-md-8">
-              {outcome}
-            </div>
-            {selectedShortSellAmount} Tokens
+    return renderedOutcomes.map((outcome, index) =>
+      (
+        <div key={index} className="row">
+          <div
+            className="entry__color col-md-4"
+            style={{ backgroundColor: colorScheme[index] }}
+          />
+          <div className="col-md-8">
+            {outcome}
           </div>
-        ),
-    )
+          {selectedShortSellAmount} Tokens
+        </div>
+      ))
   }
 
   renderCategorical() {
@@ -156,13 +154,15 @@ class MarketShortSellForm extends Component {
             <div className="col-md-4">
               <div className="row">
                 <div className="col-md-12">
-                  <h2 className="marketBuyHeading">YOUR BET</h2>
+                  <h2 className="marketBuyHeading">YOUR TRADE</h2>
                 </div>
               </div>
               <div className="row marketShortSellForm__row">
                 <div className="col-md-8">
                   <Field
-                    name="shortSellAmount" component={Input} className="marketSellAmount"
+                    name="shortSellAmount"
+                    component={Input}
+                    className="marketSellAmount"
                     placeholder="Enter amount"
                   />
                 </div>
@@ -176,7 +176,7 @@ class MarketShortSellForm extends Component {
               <div className="row marketShortSellForm__row">
                 <div className="col-md-6">
                     Maximum return
-                  </div>
+                </div>
                 <div className="col-md-6">
                   <span className="marketBuyWin__row marketBuyWin__max">
                     <DecimalValue value={maximumReturn} /> %
@@ -193,7 +193,9 @@ class MarketShortSellForm extends Component {
               <div className="row marketShortSellForm__row">
                 <div className="col-md-12">
                   <Field
-                    name="confirm" component={Checkbox} className="marketBuyCheckbox"
+                    name="confirm"
+                    component={Checkbox}
+                    className="marketBuyCheckbox"
                     text="I AGREE AND UNDERSTAND THAT ETH WILL BE TRANSFERRED FROM MY ACCOUNT"
                   />
                 </div>
@@ -212,7 +214,6 @@ class MarketShortSellForm extends Component {
       </div>
     )
   }
-
 }
 
 MarketShortSellForm.propTypes = {

--- a/src/components/ScalarSlider/index.js
+++ b/src/components/ScalarSlider/index.js
@@ -7,7 +7,9 @@ import DecimalValue from 'components/DecimalValue'
 
 import './scalarSlider.less'
 
-const ScalarSlider = ({ lowerBound, upperBound, unit, marginalPriceCurrent, marginalPriceSelected, decimals }) => {
+const ScalarSlider = ({
+  lowerBound, upperBound, unit, marginalPriceCurrent, marginalPriceSelected, decimals,
+}) => {
   const bigLowerBound = new Decimal(lowerBound)
   const bigUpperBound = new Decimal(upperBound)
 
@@ -37,7 +39,7 @@ const ScalarSlider = ({ lowerBound, upperBound, unit, marginalPriceCurrent, marg
         <div className="scalarSlider__bar" title="Please enter a value on the right!">
           <div className="scalarSlider__handle" style={currentValueSliderStyle}>
             <div className="scalarSlider__handleText">
-              <div className="scalarSlider__handleTextLabel">Current Bet</div>
+              <div className="scalarSlider__handleTextLabel">Current Trade</div>
               <DecimalValue value={value} decimals={decimals} /> {unit}
             </div>
           </div>
@@ -49,7 +51,7 @@ const ScalarSlider = ({ lowerBound, upperBound, unit, marginalPriceCurrent, marg
             style={selectedValueSliderStyle}
           >
             <div className="scalarSlider__handleText">
-              <div className="scalarSlider__handleTextLabel">Selected Bet</div>
+              <div className="scalarSlider__handleTextLabel">Selected Trade</div>
               <DecimalValue value={selectedValue} decimals={decimals} /> {unit}
             </div>
           </div>


### PR DESCRIPTION
Word "bet" is replaced with "trade" everywhere + some indent/lint fixes.

Actual changes are:
- Line 145, 237 in `src/components/MarketBuySharesForm/index.js`
- Line 157 in `src/components/MarketShortSellForm/index.js` (I'm not sure If we need this component)
- Line 42, 54 in `src/components/ScalarSlider/index.js`