### PR TITLE
Feature PM-217 Changed widget headings, Fix CSS for market list controls/dashboard

### DIFF
--- a/src/components/Dashboard/dashboard.less
+++ b/src/components/Dashboard/dashboard.less
@@ -52,12 +52,12 @@
   }
 
   &__stats {
-    margin: 50px 0;
+    margin: 42px 0;
   }
 }
 
 .dashboardControls {
-  padding: 40px 0 20px 0;
+  margin-bottom: 42px;
   
   &__button {
     margin-right: 20px;

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -246,7 +246,7 @@ class Dashboard extends Component {
     if (marketType === 'newMarkets') {
       return (
         <div className="dashboardWidget col-md-6">
-          <div className="dashboardWidget__market-title">New Markets</div>
+          <div className="dashboardWidget__market-title">Latest Markets</div>
           <div
             className={cn({
               dashboardWidget__container: true,
@@ -262,7 +262,7 @@ class Dashboard extends Component {
     if (marketType === 'closingMarkets') {
       return (
         <div className="dashboardWidget col-md-6">
-          <div className="dashboardWidget__market-title">Soon-Closing Markets</div>
+          <div className="dashboardWidget__market-title">Next Markets</div>
           <div
             className={cn({
               dashboardWidget__container: true,

--- a/src/components/MarketList/marketList.less
+++ b/src/components/MarketList/marketList.less
@@ -62,11 +62,11 @@
   }
 
   &__stats {
-    margin-top: 42px;
+    margin: 42px 0;
   }
 
   &__controls {
-    margin: 42px 0 54px 0;
+    margin-bottom: 54px;
   }
 
   &__header {


### PR DESCRIPTION
- Fix css for market list controls in case user is not an admin
**BEFORE:**
<img width="1680" alt="screen shot 2017-11-30 at 19 27 00" src="https://user-images.githubusercontent.com/16622558/33438528-9295314c-d604-11e7-9bec-cb091333924e.png">

**AFTER:**
<img width="1680" alt="screen shot 2017-11-30 at 19 26 30" src="https://user-images.githubusercontent.com/16622558/33438549-9f40c4ec-d604-11e7-8429-50945f51086d.png">

- Fix widget headings:
`New markets` > `Latest markets`
`Soon-Closing markets` > `Next markets`

- Change margin for dashboard buttom from 50 to 42 so its the same as in MarketList, also added bottom margin for stats so if the button is not shown it wont be as before pic for MarketList