### PR TITLE
BUG PM-238 Align the words

### DIFF
--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -220,14 +220,14 @@ class Dashboard extends Component {
               />
               <div className="dashboardMarket--highlight">{getOutcomeName(market, trade.outcomeToken.index)}</div>
             </div>
-            <div className="col-md-2 dashboardMarket--highlight">
-              {new Decimal(averagePrice).toFixed(4)}
-              &nbsp;{market.event ? <CurrencyName collateralToken={market.event.collateralToken} /> : <div />}
+            <div className="col-md-3 dashboardMarket--highlight">
+              {new Decimal(averagePrice).toFixed(4)}{' '}
+              {market.event ? <CurrencyName collateralToken={market.event.collateralToken} /> : <div />}
             </div>
             <div className="col-md-3 dashboardMarket--highlight">
               {moment.utc(trade.date).format(RESOLUTION_TIME.ABSOLUTE_FORMAT)}
             </div>
-            <div className="col-md-2 dashboardMarket--highlight">{TRANSACTION_DESCRIPTIONS[trade.orderType]}</div>
+            <div className="col-md-3 dashboardMarket--highlight">{TRANSACTION_DESCRIPTIONS[trade.orderType]}</div>
           </div>
         </div>
       )

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -222,7 +222,7 @@ class Dashboard extends Component {
             </div>
             <div className="col-md-3 dashboardMarket--highlight">
               {new Decimal(averagePrice).toFixed(4)}{' '}
-              {market.event ? <CurrencyName collateralToken={market.event.collateralToken} /> : <div />}
+              {market.event && <CurrencyName collateralToken={market.event.collateralToken} />}
             </div>
             <div className="col-md-3 dashboardMarket--highlight">
               {moment.utc(trade.date).format(RESOLUTION_TIME.ABSOLUTE_FORMAT)}


### PR DESCRIPTION
Increase space for columns in dashboard market list items, add a space before currency name.

**BEFORE:**
![image-2017-11-23-15-05-57-053](https://user-images.githubusercontent.com/16622558/33598372-ebfed55c-d9bb-11e7-8de8-75b1f8b67670.png)

**AFTER:**
<img width="617" alt="screen shot 2017-12-05 at 12 58 22" src="https://user-images.githubusercontent.com/16622558/33598399-00ea967c-d9bc-11e7-8a48-b3e7f630b2ca.png">

