### PR TITLE
PM-223 Make error span absolutely positioned to prevent spacing change

### DIFF
--- a/src/components/FormInput/formInput.less
+++ b/src/components/FormInput/formInput.less
@@ -1,34 +1,44 @@
-@import url('../../less/vars.less');
+@import url("../../less/vars.less");
 
-.inputField__input {
-  -webkit-appearance:none!important;
-  border: none;
-  background: none;
-  border-bottom: 1px solid @bg-color-muted;
-  color: black;
-  border-bottom-color: @bg-color-muted;
-  transition: border-bottom-color .2s ease, color .2s ease;
+.inputField {
+  &__input {
+    -webkit-appearance: none !important;
+    border: none;
+    background: none;
+    border-bottom: 1px solid @bg-color-muted;
+    color: black;
+    border-bottom-color: @bg-color-muted;
+    transition: border-bottom-color 0.2s ease, color 0.2s ease;
 
-  .inputStyles();
+    .inputStyles();
 
-  &:active, &:focus {
-    outline: 0;
+    &:active,
+    &:focus {
+      outline: 0;
+    }
+
+    &--error {
+      border-bottom-color: @active-highlight-error;
+      color: @active-highlight-error;
+    }
   }
 
-  &--error {
-    border-bottom-color: @active-highlight-error;
-    color: @active-highlight-error;
+  &__error {
+    position: absolute;
+    width: 100%;
+    text-align: center;
+    margin-top: 5px;
   }
-}
 
-.inputField__continuousPlaceholder {
-  -webkit-appearance:none!important;
-  text-align:right;
-  width:75px !important;
-  border:none;
-  border-left:0px;
-  position: absolute;
-  top:50%;
-  right: 10px;
-  background: none;
+  &continuousPlaceholder {
+    -webkit-appearance: none !important;
+    text-align: right;
+    width: 75px !important;
+    border: none;
+    border-left: 0px;
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    background: none;
+  }
 }

--- a/src/components/FormInput/index.js
+++ b/src/components/FormInput/index.js
@@ -27,6 +27,7 @@ const Input = ({
     [bemifyClassName(className, 'input', 'error')]: className && showErrorMessage,
   })
   const placeholderClassName = `inputField__continuousPlaceholder ${bemifyClassName(className, 'continuousPlaceholder')}`
+  const errorClassName = `inputField__error ${bemifyClassName(className, 'error')}`
 
   return (
     <div className={containerClassName}>
@@ -42,7 +43,7 @@ const Input = ({
           disabled
         />
       )}
-      {showErrorMessage && <span>{error}</span>}
+      {showErrorMessage && <span className={errorClassName}>{error}</span>}
     </div>
   )
 }


### PR DESCRIPTION
Make error span absolutely positioned to prevent spacing change

**Originally:**
<img width="565" alt="screen shot 2017-12-05 at 13 25 38" src="https://user-images.githubusercontent.com/16622558/33599556-edad4aa6-d9bf-11e7-8a66-eb8a80a5d1cb.png">

**Before:**
<img width="564" alt="screen shot 2017-12-05 at 13 26 14" src="https://user-images.githubusercontent.com/16622558/33599564-f5c721c6-d9bf-11e7-8d27-b57bbe3379b1.png">

**After:**
<img width="557" alt="screen shot 2017-12-05 at 13 25 50" src="https://user-images.githubusercontent.com/16622558/33599571-fa81cc48-d9bf-11e7-9f7f-88243959aed9.png">
