### PR TITLE
Fix redeemWinnings flow

### DIFF
--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -304,7 +304,7 @@ export const redeemWinnings = async (eventType, eventAddress) => {
     await gnosis.contracts.ScalarEvent.at(eventAddress)
 
   if (eventContract) {
-    await eventContract.redeemWinnings()
+    return Gnosis.requireEventFromTXResult(await eventContract.redeemWinnings(), 'WinningsRedemption')
   }
   throw new Error('Invalid Event - can\'t find the specified Event, invalid Eventtype?')
 }


### PR DESCRIPTION
If the contract exists, will exit the function as intended. Will also ensure WinningsRedemption event is fired.