### PR TITLE
Remove unused parameters to estimateGas calls

### DIFF
--- a/src/api/gnosis.js
+++ b/src/api/gnosis.js
@@ -332,55 +332,37 @@ export const calcFundingGasCost = async () => {
 
 export const calcCategoricalEventGasCost = async () => {
   const gnosis = await getGnosisConnection()
-  const gasCost = await gnosis.createCategoricalEvent.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasCost = await gnosis.createCategoricalEvent.estimateGas({ using: 'stats' })
   return gasCost
 }
 
 export const calcScalarEventGasCost = async () => {
   const gnosis = await getGnosisConnection()
-  const gasCost = await gnosis.createScalarEvent.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasCost = await gnosis.createScalarEvent.estimateGas({ using: 'stats' })
   return gasCost
 }
 
 export const calcCentralizedOracleGasCost = async () => {
   const gnosis = await getGnosisConnection()
-  const gasCost = await gnosis.createCentralizedOracle.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasCost = await gnosis.createCentralizedOracle.estimateGas({ using: 'stats' })
   return gasCost
 }
 
 export const calcMarketGasCost = async () => {
   const gnosis = await getGnosisConnection()
-  const gasCost = await gnosis.createMarket.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasCost = await gnosis.createMarket.estimateGas({ using: 'stats' })
   return gasCost
 }
 
 export const calcBuySharesGasCost = async () => {
   const gnosis = await getGnosisConnection()
-  const gasCost = await gnosis.buyOutcomeTokens.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasCost = await gnosis.buyOutcomeTokens.estimateGas({ using: 'stats' })
   return gasCost
 }
 
 export const calcSellSharesGasCost = async () => {
   const gnosis = await getGnosisConnection()
-  const gasCost = await gnosis.sellOutcomeTokens.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasCost = await gnosis.sellOutcomeTokens.estimateGas({ using: 'stats' })
   return gasCost
 }
 
@@ -397,12 +379,9 @@ export const calcRedeemWinningsGasCost = async (opts) => {
   }
 
   const gnosis = await getGnosisConnection()
-  const Event = await gnosis.contracts.Event.at(eventAddress)
+  const event = await gnosis.contracts.Event.at(eventAddress)
 
-  const gasGost = await Event.redeemWinnings.estimateGas({
-    marketFactory: gnosis.contracts.StandardMarketFactory,
-    using: 'stats',
-  })
+  const gasGost = await event.redeemWinnings.estimateGas()
   return gasGost
 }
 


### PR DESCRIPTION
This also fixes the `postMessage` issue: browser plugins like MetaMask use `postMessage` to communicate with injected scripts. `postMessage` requires that the message can be serialized completely (i.e. is something akin to plain old data/JSON).

I dunno why `marketFactory` was specified, but the `event.redeemWinnings.estimateGas` call is actually a call to the [Ethereum JS API](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3ethestimategas) and not routed through GnosisJS code (so it tries to communicate with MetaMask by default), and specifying `marketFactory` to be the `StandardMarketFactory` Truffle abstraction causes `postMessage` to choke while trying to serialize `StandardMarketFactory` for MetaMask. The Ethereum JS `estimateGas` contract calls takes the same arguments as the normal contract calls, and [`redeemWinnings`](https://gnosis.github.io/gnosis-contracts/docs/CategoricalEvent/) takes no inputs.