### PR TITLE
Adding compress and parallel options to Uglify Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "build-dev": "NODE_ENV=development ./node_modules/.bin/webpack -p --config webpack.dev.config.js",
-    "build-prod": "NODE_ENV=production ./node_modules/.bin/webpack -p --config webpack.prod.config.js",
+    "build-prod": "NODE_ENV=production ./node_modules/.bin/webpack -p --progress --config webpack.prod.config.js",
     "build": "if test \"$NODE_ENV\" = \"production\" ; then npm run build-prod; else npm run build-dev; fi ",
     "clean": "rm -rf dist",
     "start-dev": "node_modules/.bin/webpack-dev-server --hot --host 0.0.0.0 --client-log-level info --config webpack.dev.config.js --progress",
@@ -111,7 +111,7 @@
     "sass-loader": "^6.0.6",
     "style-loader": "^0.13.2",
     "truffle-hdwallet-provider": "0.0.3",
-    "uglifyjs-webpack-plugin": "^1.0.1",
+    "uglifyjs-webpack-plugin": "^1.1.4",
     "url-loader": "^0.5.9",
     "webpack": "^3.8.1",
     "webpack-dev-server": "^2.9.4"

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -114,6 +114,5 @@ module.exports = {
         compress: false,
       },
     }),
-    new UglifyJsWebpackPlugin(),
   ],
 }

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -107,6 +107,13 @@ module.exports = {
         WHITELIST: whitelist,
       },
     }),
+    new UglifyJsWebpackPlugin({
+      sourceMap: true,
+      parallel: true,
+      uglifyOptions: {
+        compress: false,
+      },
+    }),
     new UglifyJsWebpackPlugin(),
   ],
 }


### PR DESCRIPTION
This PR enables parallelisation and removes compression on files when running the UglifyPlugin in the prod webpack file.

Had to do this because compilation was stuck compiling assets.