### PR TITLE
Make reflowable column inline-block to shrinkwrap

### DIFF
--- a/src/components/MarketList/marketList.less
+++ b/src/components/MarketList/marketList.less
@@ -90,6 +90,7 @@
 .marketFilter {
   // magic number: this is the height of the text on the right, above the marketlist
   // padding-top: 31px;
+  display: inline-block;
 
   &__group {
     display: block;


### PR DESCRIPTION
This is so clicks on market list items are not blocked on narrow width displays

Just thought I would start up the [Cipher support](https://www.cipherbrowser.com/)