### PR TITLE
PM-229: Fix "Withdraw fees" button not triggering the transaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "precommit"
   ],
   "dependencies": {
-    "@gnosis.pm/gnosisjs": "1.0.1",
+    "@gnosis.pm/gnosisjs": "1.1.0",
     "autobind-decorator": "^1.4.1",
     "await-delay": "^1.0.0",
     "babel-polyfill": "^6.23.0",

--- a/src/components/MarketWithdrawFeesForm/index.js
+++ b/src/components/MarketWithdrawFeesForm/index.js
@@ -11,14 +11,15 @@ import InteractionButton from 'containers/InteractionButton'
 import './marketWithdrawFeesForm.less'
 
 class MarketWithdrawFeesForm extends Component {
-
   @autobind
   handleWithdrawFees() {
     this.props.withdrawFees(this.props.market)
   }
 
   render() {
-    const { handleSubmit, submitting, market, market: { withdrawnFees, collectedFees } } = this.props
+    const {
+      handleSubmit, submitting, market, market: { withdrawnFees, collectedFees },
+    } = this.props
     const remainingFees = new Decimal(collectedFees).sub(new Decimal(withdrawnFees))
     const submitEnabled = remainingFees.gt(0)
 
@@ -44,11 +45,11 @@ class MarketWithdrawFeesForm extends Component {
         <div className="row marketWithdrawFeesForm__row">
           <div className="col-md-6">
             <form onSubmit={handleSubmit(this.handleWithdrawFees)}>
-              
               <InteractionButton
                 className="marketWithdrawFeesForm--submit btn btn-primary"
                 disabled={!submitEnabled}
                 loading={submitting || market.local}
+                type="submit"
               >
                 Withdraw
               </InteractionButton>
@@ -63,6 +64,10 @@ class MarketWithdrawFeesForm extends Component {
 MarketWithdrawFeesForm.propTypes = {
   ...propTypes,
   handleSubmit: PropTypes.func,
+}
+
+MarketWithdrawFeesForm.defaultProps = {
+  handleSubmit: () => {},
 }
 
 const form = {


### PR DESCRIPTION
  **BEFORE**:
After pressing `Withdraw fees` transaction is not triggered.

**AFTER**:
After pressing `Withdraw fees` transaction is triggered.