### PR TITLE
PM-220: Show market creator only to whitelisted accounts

### DIFF
--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -155,13 +155,11 @@ class MarketDetail extends Component {
       market.oracle.owner === this.props.defaultAccount &&
       new Decimal(market.collectedFees).gt(0)
 
-    if (this.props.creatorIsModerator) {
+    if (this.props.isOnWhitelist) {
       // Show creator String
-      infos.creator = this.props.moderators[market.creator]
-    } else {
-      // Show address
-      infos.creator = market.creator
+      infos.creator = this.props.moderators[market.creator] || market.creator
     }
+
     if (showWithdrawFees) {
       infos['Earnings through market fees'] = `${decimalToText(weiToEth(market.collectedFees))} ${collateralTokenToText(market.event.collateralToken)}`
     }

--- a/src/containers/MarketDetailPage/index.js
+++ b/src/containers/MarketDetailPage/index.js
@@ -29,13 +29,14 @@ import {
   getMarketGraph,
 } from 'selectors/marketGraph'
 import {
+  checkWalletConnection,
   getCurrentAccount,
   getCurrentBalance,
   getGasCosts,
   getGasPrice,
   isGasCostFetched,
   isGasPriceFetched,
-  checkWalletConnection,
+  isOnWhitelist,
 } from 'selectors/blockchain'
 import { isModerator, getModerators } from 'utils/helpers'
 
@@ -77,6 +78,7 @@ const mapStateToProps = (state, ownProps) => {
     gasCosts: getGasCosts(state),
     gasPrice: getGasPrice(state),
     currentBalance: getCurrentBalance(state),
+    isOnWhitelist: isOnWhitelist(state),
   }
 }
 


### PR DESCRIPTION
**BEFORE**:
Everyone can see market creator's name/address from whitelist.

**AFTER**:
Only whitelisted accounts can see market creator's name/address.