### PR TITLE
Feature PM-411 creation action reducers market list route

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,13 +1,13 @@
 {
   "presets": [
-    "react",
+    "@babel/react",
     [
-      "env",
+      "@babel/preset-env",
       {
         "forceAllTransforms": true
       }
     ],
-    "stage-0"
+    "@babel/preset-stage-0"
   ],
   "plugins": [
     "react-hot-loader/babel",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint ./src --quiet",
     "lint:fix": "eslint ./src --fix --quiet",
     "test": "jest --no-cache",
+    "test:watch": "npm test -- --watch",
     "precommit": "./precommit.sh"
   },
   "repository": {
@@ -24,10 +25,6 @@
   "author": "Gnosis",
   "license": "ISC",
   "jest": {
-    "transform": {
-      "^.+\\.js$": "babel-jest",
-      "^.+\\.(css|scss)$": "<rootDir>/node_modules/jest-css-modules"
-    },
     "modulePaths": [
       "<rootDir>/src/"
     ]
@@ -77,21 +74,22 @@
     "web3": "^1.0.0-beta.29"
   },
   "devDependencies": {
+    "@babel/cli": "^7.0.0-beta.39",
+    "@babel/core": "^7.0.0-beta.39",
+    "@babel/preset-env": "^7.0.0-beta.39",
+    "@babel/preset-react": "^7.0.0-beta.39",
+    "@babel/preset-stage-0": "^7.0.0-beta.39",
     "@storybook/addon-actions": "^3.3.12",
     "@storybook/addon-knobs": "^3.3.12",
     "@storybook/addon-links": "^3.3.12",
     "@storybook/react": "^3.3.12",
     "autoprefixer": "^7.1.6",
-    "babel-core": "6.26.0",
-    "babel-eslint": "^8.0.2",
-    "babel-loader": "7.1.2",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^22.2.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-lodash": "^3.2.11",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.8",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "6.24.1",
-    "babel-preset-stage-0": "6.24.1",
     "bootstrap-loader": "^2.1.0",
     "bootstrap-sass": "^3.3.7",
     "css-loader": "^0.28.9",
@@ -99,15 +97,14 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-loader": "^1.9.0",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^21.3.2",
+    "eslint-plugin-jest": "^21.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.4.0",
     "extract-text-webpack-plugin": "^3.0.2",
     "favicons-webpack-plugin": "0.0.7",
     "file-loader": "^1.1.6",
     "html-webpack-plugin": "^2.28.0",
-    "jest": "^22.1.4",
-    "jest-css-modules": "^1.1.0",
+    "jest": "^22.2.0",
     "json-loader": "^0.5.7",
     "node-sass": "^4.5.3",
     "postcss-loader": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "d3-scale-chromatic": "^1.1.1",
     "decimal.js": "^9.0.1",
     "history": "^4.7.2",
+    "immutable": "^3.8.2",
     "lodash": "^4.17.5",
     "moment": "^2.19.2",
     "moment-duration-format": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "@storybook/react": "^3.3.12",
     "autoprefixer": "^7.1.6",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-eslint": "^7.2.3",
     "babel-jest": "^22.2.0",
     "babel-plugin-dynamic-import-node": "^1.2.0",
     "babel-plugin-lodash": "^3.2.11",

--- a/src/api/rest.js
+++ b/src/api/rest.js
@@ -20,6 +20,7 @@ export const requestMarket = async marketAddress =>
   restFetch(`${API_URL}/markets/${hexWithoutPrefix(marketAddress)}/`).then(response =>
     normalize({ ...response, local: false }, marketSchema))
 
+// TODO delete when src/routes/marketlist is fully operative
 export const requestMarkets = async () => {
   const url = `${API_URL}/markets/?${whitelistedAddressesFilter}`
 

--- a/src/api/utils/fetch.js
+++ b/src/api/utils/fetch.js
@@ -1,0 +1,19 @@
+/* globals fetch */
+import qs from 'querystring'
+
+const API_URL = `${process.env.GNOSISDB_URL}/api`
+
+export const requestFromRestAPI = async (endpoint, queryparams) => {
+  const url = `${API_URL}/${endpoint}?${qs.stringify(queryparams)}`
+  const response = await fetch(url)
+
+  if (response.status > 400) {
+    throw new Error('GnosisDB: Couldn\'t fetch (invalid statuscode)')
+  }
+
+  try {
+    return response.json()
+  } catch (e) {
+    throw new Error('GnosisDB: Couldn\'t fetch (format error)')
+  }
+}

--- a/src/routes/marketlist/store/actions/addMarkets.js
+++ b/src/routes/marketlist/store/actions/addMarkets.js
@@ -1,0 +1,5 @@
+import { createAction } from 'redux-actions'
+
+export const ADD_MARKET_LIST = 'ADD_MARKET_LIST'
+
+export default createAction(ADD_MARKET_LIST)

--- a/src/routes/marketlist/store/actions/fetchMarkets.js
+++ b/src/routes/marketlist/store/actions/fetchMarkets.js
@@ -14,8 +14,10 @@ const buildOutcomesFrom = (outcomes, marginalPrices) => {
     return List([])
   }
 
-  const outcomesRecords = outcomes.map((outcome, index) =>
-    new OutcomeRecord({ outcome, marginalPrice: marginalPrices[index] }))
+  const outcomesRecords = outcomes.map((outcome, index) => new OutcomeRecord({
+    name: outcome,
+    marginalPrice: marginalPrices[index],
+  }))
 
   return List(outcomesRecords)
 }

--- a/src/routes/marketlist/store/actions/fetchMarkets.js
+++ b/src/routes/marketlist/store/actions/fetchMarkets.js
@@ -7,12 +7,15 @@ import addMarkets from './addMarkets'
 const whitelisted = process.env.WHITELIST || {}
 const addresses = Object.keys(whitelisted).map(address => hexWithoutPrefix(address))
 
+export const processMarketResponse = (dispatch, response) => {
+  if (!response || !response.results) {
+    dispatch(addMarkets([]))
+    return
+  }
+
+  dispatch(addMarkets(response.results))
+}
+
 export default () => dispatch =>
   requestFromRestAPI('markets', { creator: addresses.join() })
-    .then((response) => {
-      if (!response) {
-        dispatch(addMarkets([]))
-      }
-
-      dispatch(addMarkets(response.results))
-    })
+    .then(response => processMarketResponse(dispatch, response))

--- a/src/routes/marketlist/store/actions/fetchMarkets.js
+++ b/src/routes/marketlist/store/actions/fetchMarkets.js
@@ -1,0 +1,18 @@
+import { requestFromRestAPI } from 'api/fetch'
+import { hexWithoutPrefix } from 'utils/helpers'
+import addMarkets from './addMarkets'
+
+// TODO The default assignment is because JEST test do not work out of the box
+// with ENV variables. Fix that using the plugin dotenv(for example)
+const whitelisted = process.env.WHITELIST || {}
+const addresses = Object.keys(whitelisted).map(address => hexWithoutPrefix(address))
+
+export default () => dispatch =>
+  requestFromRestAPI('markets', { creator: addresses.join() })
+    .then((response) => {
+      if (!response) {
+        dispatch(addMarkets([]))
+      }
+
+      dispatch(addMarkets(response.results))
+    })

--- a/src/routes/marketlist/store/actions/fetchMarkets.js
+++ b/src/routes/marketlist/store/actions/fetchMarkets.js
@@ -1,5 +1,7 @@
+import { List } from 'immutable'
 import { requestFromRestAPI } from 'api/utils/fetch'
 import { hexWithoutPrefix } from 'utils/helpers'
+import { BoundsRecord, MarketRecord, OutcomeRecord } from '../models'
 import addMarkets from './addMarkets'
 
 // TODO The default assignment is because JEST test do not work out of the box
@@ -7,13 +9,43 @@ import addMarkets from './addMarkets'
 const whitelisted = process.env.WHITELIST || {}
 const addresses = Object.keys(whitelisted).map(address => hexWithoutPrefix(address))
 
+const buildOutcomesFrom = (outcomes, marginalPrices) => {
+  if (!outcomes) {
+    return List([])
+  }
+
+  const outcomesRecords = outcomes.map((outcome, index) =>
+    new OutcomeRecord({ outcome, marginalPrice: marginalPrices[index] }))
+
+  return List(outcomesRecords)
+}
+
+const buildBoundsFrom = (lower, upper, unit) => BoundsRecord({ lower, upper, unit })
+
+const extractMarkets = markets => markets.map((market) => {
+  const { eventDescription } = market.event.oracle
+  const { title, resolutionDate: date, outcomes: outcomesResponse } = eventDescription
+  const volume = market.tradingVolume
+  const { type } = market.event
+  const outcomes = buildOutcomesFrom(outcomesResponse, market.marginalPrices)
+  const { unit } = market.event.oracle.eventDescription
+  const bounds = buildBoundsFrom(market.event.lowerBound, market.event.upperBound, unit)
+
+  // eslint-disable-next-line
+  const marketRecord = new MarketRecord({ title, date, volume, type, outcomes, bounds });
+
+  return marketRecord
+})
+
+
 export const processMarketResponse = (dispatch, response) => {
   if (!response || !response.results) {
     dispatch(addMarkets([]))
     return
   }
 
-  dispatch(addMarkets(response.results))
+  const marketRecords = extractMarkets(response.results)
+  dispatch(addMarkets(marketRecords))
 }
 
 export default () => dispatch =>

--- a/src/routes/marketlist/store/actions/fetchMarkets.js
+++ b/src/routes/marketlist/store/actions/fetchMarkets.js
@@ -1,4 +1,4 @@
-import { requestFromRestAPI } from 'api/fetch'
+import { requestFromRestAPI } from 'api/utils/fetch'
 import { hexWithoutPrefix } from 'utils/helpers'
 import addMarkets from './addMarkets'
 

--- a/src/routes/marketlist/store/actions/index.js
+++ b/src/routes/marketlist/store/actions/index.js
@@ -1,0 +1,1 @@
+export { default as fetchMarkets } from './fetchMarkets'

--- a/src/routes/marketlist/store/actions/index.js
+++ b/src/routes/marketlist/store/actions/index.js
@@ -1,1 +1,3 @@
+export * from 'addMarkets'
+export { default as addMarkets } from './addMarkets'
 export { default as fetchMarkets } from './fetchMarkets'

--- a/src/routes/marketlist/store/models/bound.js
+++ b/src/routes/marketlist/store/models/bound.js
@@ -1,0 +1,9 @@
+import { Record } from 'immutable'
+
+const Bound = Record({
+  lower: undefined,
+  upper: undefined,
+  unit: undefined,
+}, 'Bound')
+
+export default Bound

--- a/src/routes/marketlist/store/models/bounds.js
+++ b/src/routes/marketlist/store/models/bounds.js
@@ -1,9 +1,9 @@
 import { Record } from 'immutable'
 
-const Bound = Record({
+const BoundsRecord = Record({
   lower: undefined,
   upper: undefined,
   unit: undefined,
 }, 'Bound')
 
-export default Bound
+export default BoundsRecord

--- a/src/routes/marketlist/store/models/index.js
+++ b/src/routes/marketlist/store/models/index.js
@@ -1,4 +1,4 @@
-export { default as BoundRecord } from './bound'
+export { default as BoundsRecord } from './bounds'
 export * from './market'
 export { default as MarketRecord } from './market'
 export { default as OutcomeRecord } from './outcome'

--- a/src/routes/marketlist/store/models/index.js
+++ b/src/routes/marketlist/store/models/index.js
@@ -1,0 +1,4 @@
+export { default as BoundRecord } from './bound'
+export * from './market'
+export { default as MarketRecord } from './market'
+export { default as OutcomeRecord } from './outcome'

--- a/src/routes/marketlist/store/models/market.js
+++ b/src/routes/marketlist/store/models/market.js
@@ -1,0 +1,16 @@
+import { List, Record } from 'immutable'
+
+export const MarketListRecord = Record({
+  marketList: List([]), // Immutable.List<Market>
+})
+
+const Market = Record({
+  title: undefined, // string
+  date: undefined, // ts
+  volume: undefined, // decimal
+  type: undefined, // enum {CATEGORICAL, SCALAR}
+  outcomes: undefined, // List<Outcome>
+  bounds: undefined, // BoundRecord
+}, 'Market')
+
+export default Market

--- a/src/routes/marketlist/store/models/market.js
+++ b/src/routes/marketlist/store/models/market.js
@@ -1,6 +1,9 @@
 import { Record } from 'immutable'
 
-const Market = Record({
+export const MARKET_SCALAR = 'SCALAR'
+export const MARKET_CATEGORICAL = 'CATEGORICAL'
+
+const MarketRecord = Record({
   title: undefined, // string
   date: undefined, // ts
   volume: undefined, // decimal
@@ -9,4 +12,4 @@ const Market = Record({
   bounds: undefined, // BoundRecord
 }, 'Market')
 
-export default Market
+export default MarketRecord

--- a/src/routes/marketlist/store/models/market.js
+++ b/src/routes/marketlist/store/models/market.js
@@ -1,8 +1,4 @@
-import { List, Record } from 'immutable'
-
-export const MarketListRecord = Record({
-  marketList: List([]), // Immutable.List<Market>
-})
+import { Record } from 'immutable'
 
 const Market = Record({
   title: undefined, // string

--- a/src/routes/marketlist/store/models/outcome.js
+++ b/src/routes/marketlist/store/models/outcome.js
@@ -1,8 +1,8 @@
 import { Record } from 'immutable'
 
-const Outcome = Record({
+const OutcomeRecord = Record({
   name: undefined, // string
   marginalPrice: undefined, // decimal
 }, 'Outcome')
 
-export default Outcome
+export default OutcomeRecord

--- a/src/routes/marketlist/store/models/outcome.js
+++ b/src/routes/marketlist/store/models/outcome.js
@@ -1,0 +1,8 @@
+import { Record } from 'immutable'
+
+const Outcome = Record({
+  name: undefined, // string
+  marginalPrice: undefined, // decimal
+}, 'Outcome')
+
+export default Outcome

--- a/src/routes/marketlist/store/reducers/market.builder.js
+++ b/src/routes/marketlist/store/reducers/market.builder.js
@@ -1,5 +1,3 @@
-export const emptyMarkets = () => []
-
 const aMarket = () => ({ })
 
 export default aMarket

--- a/src/routes/marketlist/store/reducers/market.builder.js
+++ b/src/routes/marketlist/store/reducers/market.builder.js
@@ -1,3 +1,233 @@
-const aMarket = () => ({ })
+import { List } from 'immutable'
+import { MarketRecord, BoundsRecord } from '../models'
+
+/* eslint-disable */
+export const realData = {
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "contract": {
+        "creationBlock": 4818543,
+        "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+        "factoryAddress": "0xdde21f8be9e50b9b1165ee302e6b468cf30e4c4c",
+        "creationDate": "2017-12-29T13:39:44",
+        "address": "0xa625c9ccf5860e9709a31cbac1ffd6fc557558f6"
+      },
+      "event": {
+        "contract": {
+          "creationBlock": 4818540,
+          "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "factoryAddress": "0x5b21ba38a0db91cc43aa7daba778979758e67991",
+          "creationDate": "2017-12-29T13:39:29",
+          "address": "0x2077708a049f059ee7a7878071b5adca92e6a4ba"
+        },
+        "collateralToken": "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "oracle": {
+          "contract": {
+            "creationBlock": 4818537,
+            "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+            "factoryAddress": "0xc4f4b8c0259c8264376fc32984e2a8cf4a3c70ca",
+            "creationDate": "2017-12-29T13:39:02",
+            "address": "0x02d7f617bc27b2a09675d2c095c1d0ffc761afd5"
+          },
+          "isOutcomeSet": false,
+          "owner": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "eventDescription": {
+            "ipfsHash": "QmfGcwGtG7LoPSD3wQk3hNNKZkRAszAgrzeS6GrB7Us9np",
+            "description": "How much of the total Ethereum transactions in the last 1500 blocks will be made by CryptoKitties game actions in the Ethereum network? The winning outcome will be calculated according to the sum of interactions with the smart contract address: 0x06012c8cf97bead5deae237070f9587f8e7a266d (CryptoKitties) and the address: 0xb1690c08e213a35ed9bab7b318de14420fb57d8c (CryptoKitties Auction) which make up for all the interactions made with CryptoKitties contracts. Source: https://ethgasstation.info/gasguzzlers.php",
+            "title": "How much will Cryptokitties transactions make up of the entire Ethereum network transactions by December 29th, in the last 1500 blocks?",
+            "resolutionDate": "2017-12-30T00:00:00",
+            "decimals": 0,
+            "unit": "%"
+          },
+          "type": "CENTRALIZED"
+        },
+        "isWinningOutcomeSet": false,
+        "lowerBound": "1",
+        "upperBound": "20",
+        "type": "SCALAR"
+      },
+      "marketMaker": "7ee6e9dc512b0fe5cb5e28697cfc34375a9adc4b",
+      "fee": 0,
+      "funding": "10000000000000000",
+      "netOutcomeTokensSold": [
+        "15211146333519251",
+        "0"
+      ],
+      "stage": 1,
+      "tradingVolume": "9523809523809680",
+      "withdrawnFees": "0",
+      "collectedFees": "0",
+      "marginalPrices": [
+        "0.7416",
+        "0.2584"
+      ]
+    },
+    {
+      "contract": {
+        "creationBlock": 4830058,
+        "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+        "factoryAddress": "0xdde21f8be9e50b9b1165ee302e6b468cf30e4c4c",
+        "creationDate": "2017-12-31T13:12:51",
+        "address": "0xedb69ab6fa7a1740f91f7dec0c667873269bea96"
+      },
+      "event": {
+        "contract": {
+          "creationBlock": 4830056,
+          "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "factoryAddress": "0x5b21ba38a0db91cc43aa7daba778979758e67991",
+          "creationDate": "2017-12-31T13:12:00",
+          "address": "0x471f34c2b6addf8d501c7b3a157701633be3eb79"
+        },
+        "collateralToken": "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "oracle": {
+          "contract": {
+            "creationBlock": 4830054,
+            "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+            "factoryAddress": "0xc4f4b8c0259c8264376fc32984e2a8cf4a3c70ca",
+            "creationDate": "2017-12-31T13:11:37",
+            "address": "0xe5c7fd34f0053ad1cb0f6892082f347f08c8133d"
+          },
+          "isOutcomeSet": false,
+          "owner": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "eventDescription": {
+            "ipfsHash": "QmNTiWX57wcHTEromRzLtJLpSmEd15rj7ATShBVgaChrzu",
+            "description": "You can check the progress and number of Ethereum transactions here: https://etherscan.io/chart/tx",
+            "title": "What will the number of Ethereum transactions be on January 3rd, 2018?",
+            "resolutionDate": "2018-01-03T12:00:00",
+            "decimals": 0,
+            "unit": "Txs"
+          },
+          "type": "CENTRALIZED"
+        },
+        "isWinningOutcomeSet": false,
+        "lowerBound": "500000",
+        "upperBound": "1250000",
+        "type": "SCALAR"
+      },
+      "marketMaker": "7ee6e9dc512b0fe5cb5e28697cfc34375a9adc4b",
+      "fee": 0,
+      "funding": "1000000000000000000",
+      "netOutcomeTokensSold": [
+        "0",
+        "1391159866011082687"
+      ],
+      "stage": 1,
+      "tradingVolume": "857142857142872776",
+      "withdrawnFees": "0",
+      "collectedFees": "0",
+      "marginalPrices": [
+        "0.2760",
+        "0.7240"
+      ]
+    },
+    {
+      "contract": {
+        "creationBlock": 4830266,
+        "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+        "factoryAddress": "0xdde21f8be9e50b9b1165ee302e6b468cf30e4c4c",
+        "creationDate": "2017-12-31T13:58:13",
+        "address": "0xa8d84fc1fc77c87203c1448587ebdb5ee845f26b"
+      },
+      "event": {
+        "contract": {
+          "creationBlock": 4830264,
+          "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "factoryAddress": "0x5b21ba38a0db91cc43aa7daba778979758e67991",
+          "creationDate": "2017-12-31T13:57:54",
+          "address": "0xf43c5e4113aaeb07e4b18a80537ec6cd52213e1e"
+        },
+        "collateralToken": "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "oracle": {
+          "contract": {
+            "creationBlock": 4830255,
+            "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+            "factoryAddress": "0xc4f4b8c0259c8264376fc32984e2a8cf4a3c70ca",
+            "creationDate": "2017-12-31T13:54:44",
+            "address": "0xd8b16d799718e23cc2adfbe1107d1489bf1de9c5"
+          },
+          "isOutcomeSet": false,
+          "owner": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "eventDescription": {
+            "outcomes": [
+              "<20 GWei",
+              "20 GWei",
+              ">20 GWei"
+            ],
+            "ipfsHash": "QmfAQHNR8NRjeiVyPzMPkRXp6EQ3oExZFYfNBxQhcR6ihz",
+            "description": "What will be the median gas price payed among all transactions on Feb. 1st, 2018?",
+            "resolutionDate": "2018-02-01T12:00:00",
+            "title": "What will be the median gas price on Feb. 1st, 2018?"
+          },
+          "type": "CENTRALIZED"
+        },
+        "isWinningOutcomeSet": false,
+        "type": "CATEGORICAL"
+      },
+      "marketMaker": "7ee6e9dc512b0fe5cb5e28697cfc34375a9adc4b",
+      "fee": 0,
+      "funding": "1000000000000000000",
+      "netOutcomeTokensSold": [
+        "0",
+        "375216952973444123",
+        "566120592814650422"
+      ],
+      "stage": 1,
+      "tradingVolume": "342952380952380954",
+      "withdrawnFees": "0",
+      "collectedFees": "0",
+      "marginalPrices": [
+        "0.2287",
+        "0.3454",
+        "0.4259"
+      ]
+    }
+  ]
+}
+/* eslint-enable */
+
+class MarketBuilder {
+  constructor() {
+    this.market = new MarketRecord()
+  }
+
+  withTitle(title) {
+    this.market = this.market.set('title', title)
+    return this
+  }
+
+  withDate(date) {
+    this.market = this.market.set('date', date)
+    return this
+  }
+
+  withVolume(volume) {
+    this.market = this.market.set('volume', volume)
+    return this
+  }
+
+  withType(type) {
+    this.market = this.market.set('type', type)
+    return this
+  }
+
+  withOutcomes(outcomes) {
+    this.market = this.market.set('outcomes', List(outcomes))
+    return this
+  }
+
+  withBounds(lower, upper, unit) {
+    this.market = this.market.set('bounds', new BoundsRecord({ lower, upper, unit }))
+    return this
+  }
+
+  get() {
+    return this.market
+  }
+}
+
+const aMarket = () => new MarketBuilder()
 
 export default aMarket

--- a/src/routes/marketlist/store/reducers/market.builder.js
+++ b/src/routes/marketlist/store/reducers/market.builder.js
@@ -1,7 +1,206 @@
 import { List } from 'immutable'
-import { MarketRecord, BoundsRecord } from '../models'
+import {
+  MarketRecord,
+  BoundsRecord,
+  OutcomeRecord,
+  MARKET_CATEGORICAL,
+  MARKET_SCALAR,
+} from '../models'
 
 /* eslint-disable */
+export const oneMarketData = {
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "contract": {
+        "creationBlock": 4818543,
+        "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+        "factoryAddress": "0xdde21f8be9e50b9b1165ee302e6b468cf30e4c4c",
+        "creationDate": "2017-12-29T13:39:44",
+        "address": "0xa625c9ccf5860e9709a31cbac1ffd6fc557558f6"
+      },
+      "event": {
+        "contract": {
+          "creationBlock": 4818540,
+          "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "factoryAddress": "0x5b21ba38a0db91cc43aa7daba778979758e67991",
+          "creationDate": "2017-12-29T13:39:29",
+          "address": "0x2077708a049f059ee7a7878071b5adca92e6a4ba"
+        },
+        "collateralToken": "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "oracle": {
+          "contract": {
+            "creationBlock": 4818537,
+            "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+            "factoryAddress": "0xc4f4b8c0259c8264376fc32984e2a8cf4a3c70ca",
+            "creationDate": "2017-12-29T13:39:02",
+            "address": "0x02d7f617bc27b2a09675d2c095c1d0ffc761afd5"
+          },
+          "isOutcomeSet": false,
+          "owner": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "eventDescription": {
+            "ipfsHash": "QmfGcwGtG7LoPSD3wQk3hNNKZkRAszAgrzeS6GrB7Us9np",
+            "description": "How much of the total Ethereum transactions in the last 1500 blocks will be made by CryptoKitties game actions in the Ethereum network? The winning outcome will be calculated according to the sum of interactions with the smart contract address: 0x06012c8cf97bead5deae237070f9587f8e7a266d (CryptoKitties) and the address: 0xb1690c08e213a35ed9bab7b318de14420fb57d8c (CryptoKitties Auction) which make up for all the interactions made with CryptoKitties contracts. Source: https://ethgasstation.info/gasguzzlers.php",
+            "title": "How much will Cryptokitties transactions make up of the entire Ethereum network transactions by December 29th, in the last 1500 blocks?",
+            "resolutionDate": "2017-12-30T00:00:00",
+            "decimals": 0,
+            "unit": "%"
+          },
+          "type": "CENTRALIZED"
+        },
+        "isWinningOutcomeSet": false,
+        "lowerBound": "1",
+        "upperBound": "20",
+        "type": "SCALAR"
+      },
+      "marketMaker": "7ee6e9dc512b0fe5cb5e28697cfc34375a9adc4b",
+      "fee": 0,
+      "funding": "10000000000000000",
+      "netOutcomeTokensSold": [
+        "15211146333519251",
+        "0"
+      ],
+      "stage": 1,
+      "tradingVolume": "9523809523809680",
+      "withdrawnFees": "0",
+      "collectedFees": "0",
+      "marginalPrices": [
+        "0.7416",
+        "0.2584"
+      ]
+    }
+  ]
+}
+
+export const twoMarketData = {
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "contract": {
+        "creationBlock": 4830058,
+        "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+        "factoryAddress": "0xdde21f8be9e50b9b1165ee302e6b468cf30e4c4c",
+        "creationDate": "2017-12-31T13:12:51",
+        "address": "0xedb69ab6fa7a1740f91f7dec0c667873269bea96"
+      },
+      "event": {
+        "contract": {
+          "creationBlock": 4830056,
+          "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "factoryAddress": "0x5b21ba38a0db91cc43aa7daba778979758e67991",
+          "creationDate": "2017-12-31T13:12:00",
+          "address": "0x471f34c2b6addf8d501c7b3a157701633be3eb79"
+        },
+        "collateralToken": "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "oracle": {
+          "contract": {
+            "creationBlock": 4830054,
+            "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+            "factoryAddress": "0xc4f4b8c0259c8264376fc32984e2a8cf4a3c70ca",
+            "creationDate": "2017-12-31T13:11:37",
+            "address": "0xe5c7fd34f0053ad1cb0f6892082f347f08c8133d"
+          },
+          "isOutcomeSet": false,
+          "owner": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "eventDescription": {
+            "ipfsHash": "QmNTiWX57wcHTEromRzLtJLpSmEd15rj7ATShBVgaChrzu",
+            "description": "You can check the progress and number of Ethereum transactions here: https://etherscan.io/chart/tx",
+            "title": "What will the number of Ethereum transactions be on January 3rd, 2018?",
+            "resolutionDate": "2018-01-03T12:00:00",
+            "decimals": 0,
+            "unit": "Txs"
+          },
+          "type": "CENTRALIZED"
+        },
+        "isWinningOutcomeSet": false,
+        "lowerBound": "500000",
+        "upperBound": "1250000",
+        "type": "SCALAR"
+      },
+      "marketMaker": "7ee6e9dc512b0fe5cb5e28697cfc34375a9adc4b",
+      "fee": 0,
+      "funding": "1000000000000000000",
+      "netOutcomeTokensSold": [
+        "0",
+        "1391159866011082687"
+      ],
+      "stage": 1,
+      "tradingVolume": "857142857142872776",
+      "withdrawnFees": "0",
+      "collectedFees": "0",
+      "marginalPrices": [
+        "0.2760",
+        "0.7240"
+      ]
+    },
+    {
+      "contract": {
+        "creationBlock": 4830266,
+        "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+        "factoryAddress": "0xdde21f8be9e50b9b1165ee302e6b468cf30e4c4c",
+        "creationDate": "2017-12-31T13:58:13",
+        "address": "0xa8d84fc1fc77c87203c1448587ebdb5ee845f26b"
+      },
+      "event": {
+        "contract": {
+          "creationBlock": 4830264,
+          "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "factoryAddress": "0x5b21ba38a0db91cc43aa7daba778979758e67991",
+          "creationDate": "2017-12-31T13:57:54",
+          "address": "0xf43c5e4113aaeb07e4b18a80537ec6cd52213e1e"
+        },
+        "collateralToken": "c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        "oracle": {
+          "contract": {
+            "creationBlock": 4830255,
+            "creator": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+            "factoryAddress": "0xc4f4b8c0259c8264376fc32984e2a8cf4a3c70ca",
+            "creationDate": "2017-12-31T13:54:44",
+            "address": "0xd8b16d799718e23cc2adfbe1107d1489bf1de9c5"
+          },
+          "isOutcomeSet": false,
+          "owner": "0x9eab578556de5782445ec036f25a41902ba19eeb",
+          "eventDescription": {
+            "outcomes": [
+              "<20 GWei",
+              "20 GWei",
+              ">20 GWei"
+            ],
+            "ipfsHash": "QmfAQHNR8NRjeiVyPzMPkRXp6EQ3oExZFYfNBxQhcR6ihz",
+            "description": "What will be the median gas price payed among all transactions on Feb. 1st, 2018?",
+            "resolutionDate": "2018-02-01T12:00:00",
+            "title": "What will be the median gas price on Feb. 1st, 2018?"
+          },
+          "type": "CENTRALIZED"
+        },
+        "isWinningOutcomeSet": false,
+        "type": "CATEGORICAL"
+      },
+      "marketMaker": "7ee6e9dc512b0fe5cb5e28697cfc34375a9adc4b",
+      "fee": 0,
+      "funding": "1000000000000000000",
+      "netOutcomeTokensSold": [
+        "0",
+        "375216952973444123",
+        "566120592814650422"
+      ],
+      "stage": 1,
+      "tradingVolume": "342952380952380954",
+      "withdrawnFees": "0",
+      "collectedFees": "0",
+      "marginalPrices": [
+        "0.2287",
+        "0.3454",
+        "0.4259"
+      ]
+    }
+  ]
+}
+
 export const realData = {
   "count": 3,
   "next": null,
@@ -213,7 +412,7 @@ class MarketBuilder {
     return this
   }
 
-  withOutcomes(outcomes) {
+  withOutcomes(...outcomes) {
     this.market = this.market.set('outcomes', List(outcomes))
     return this
   }
@@ -229,5 +428,38 @@ class MarketBuilder {
 }
 
 const aMarket = () => new MarketBuilder()
+
+export class MarketFactory {
+  static aKittiesMarket = aMarket()
+    .withTitle('How much will Cryptokitties transactions make up of the entire Ethereum network transactions by December 29th, in the last 1500 blocks?')
+    .withDate('2017-12-30T00:00:00')
+    .withVolume('9523809523809680')
+    .withType(MARKET_SCALAR)
+    .withOutcomes()
+    .withBounds('1', '20', '%')
+    .get()
+
+  static aEthereumMarket = aMarket()
+    .withTitle('What will the number of Ethereum transactions be on January 3rd, 2018?')
+    .withDate('2018-01-03T12:00:00')
+    .withVolume('857142857142872776')
+    .withType(MARKET_SCALAR)
+    .withOutcomes()
+    .withBounds('500000', '1250000', 'Txs')
+    .get()
+
+  static aGasPriceMarket = aMarket()
+    .withTitle('What will be the median gas price on Feb. 1st, 2018?')
+    .withDate('2018-02-01T12:00:00')
+    .withVolume('342952380952380954')
+    .withType(MARKET_CATEGORICAL)
+    .withOutcomes(
+      new OutcomeRecord({ name: '<20 GWei', marginalPrice: '0.2287' }),
+      new OutcomeRecord({ name: '20 GWei', marginalPrice: '0.3454' }),
+      new OutcomeRecord({ name: '>20 GWei', marginalPrice: '0.4259' }),
+    )
+    .withBounds(undefined, undefined, undefined)
+    .get()
+}
 
 export default aMarket

--- a/src/routes/marketlist/store/reducers/market.builder.js
+++ b/src/routes/marketlist/store/reducers/market.builder.js
@@ -1,0 +1,5 @@
+export const emptyMarkets = () => []
+
+const aMarket = () => ({ })
+
+export default aMarket

--- a/src/routes/marketlist/store/reducers/market.js
+++ b/src/routes/marketlist/store/reducers/market.js
@@ -1,10 +1,11 @@
 import { List } from 'immutable'
 import { handleActions } from 'redux-actions'
 import { ADD_MARKET_LIST } from '../actions'
-import { MarketListRecord } from '../models'
+
+export const REDUCER_ID = 'marketList'
 
 export default handleActions({
   [ADD_MARKET_LIST]: (state, { payload }) =>
-    state.set('marketList', List(payload)),
-}, new MarketListRecord())
+    state.set(List(payload)),
+}, List([]))
 

--- a/src/routes/marketlist/store/reducers/market.js
+++ b/src/routes/marketlist/store/reducers/market.js
@@ -1,0 +1,10 @@
+import { List } from 'immutable'
+import { handleActions } from 'redux-actions'
+import { ADD_MARKET_LIST } from '../actions'
+import { MarketListRecord } from '../models'
+
+export default handleActions({
+  [ADD_MARKET_LIST]: (state, { payload }) =>
+    state.set('marketList', List(payload)),
+}, new MarketListRecord())
+

--- a/src/routes/marketlist/store/reducers/market.js
+++ b/src/routes/marketlist/store/reducers/market.js
@@ -1,11 +1,11 @@
 import { List } from 'immutable'
 import { handleActions } from 'redux-actions'
-import { ADD_MARKET_LIST } from '../actions'
+import { ADD_MARKET_LIST } from '../actions/addMarkets'
 
 export const REDUCER_ID = 'marketList'
 
 export default handleActions({
   [ADD_MARKET_LIST]: (state, { payload }) =>
-    state.set(List(payload)),
+    List(payload),
 }, List([]))
 

--- a/src/routes/marketlist/store/reducers/market.spec.js
+++ b/src/routes/marketlist/store/reducers/market.spec.js
@@ -1,22 +1,36 @@
+import { combineReducers, createStore, applyMiddleware, compose } from 'redux'
+import thunk from 'redux-thunk'
 import { List } from 'immutable'
-import marketReducer from './market'
-import { MarketListRecord } from '../models'
-import { emptyMarkets } from './market.builder'
-import addMarkets from '../actions/addMarkets'
+import { processMarketResponse } from '../actions/fetchMarkets'
+import marketReducer, { REDUCER_ID } from './market'
 
 describe('Market List Actions', () => {
-  it('should return the initial state when no markets are loaded', () => {
-    // GIVEN
-    const initialState = undefined
-    const marketAction = addMarkets(emptyMarkets())
-    const reduxState = marketReducer(initialState, marketAction)
+  let store
+  beforeEach(() => {
+    const reducers = combineReducers({
+      [REDUCER_ID]: marketReducer,
+    })
+    const middlewares = [
+      thunk,
+    ]
+    const enhancers = [
+      applyMiddleware(...middlewares),
+    ]
+    store = createStore(reducers, compose(...enhancers))
+  })
 
-    const emptyListOfMarkets = List(emptyMarkets())
+
+  it('should return empty Immutable list when no markets are loaded', () => {
+    // GIVEN
+    const emptyResponse = { }
 
     // WHEN
-    const emptyMarketListRecord = new MarketListRecord(emptyListOfMarkets)
+    processMarketResponse(store.dispatch, emptyResponse)
+
     // THEN
-    expect(reduxState).toEqual(emptyMarketListRecord)
+    const emptyList = List([])
+    const marketListState = store.getState().marketList
+    expect(marketListState).toEqual(emptyList)
   })
 
   it('store Market records in store ', () => {

--- a/src/routes/marketlist/store/reducers/market.spec.js
+++ b/src/routes/marketlist/store/reducers/market.spec.js
@@ -1,0 +1,5 @@
+describe('Market List Actions', () => {
+  it('store Market records in store ', () => {
+    expect(true).toEqual(true)
+  })
+})

--- a/src/routes/marketlist/store/reducers/market.spec.js
+++ b/src/routes/marketlist/store/reducers/market.spec.js
@@ -2,7 +2,7 @@ import { combineReducers, createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 import { List } from 'immutable'
 import { processMarketResponse } from '../actions/fetchMarkets'
-import { MARKET_CATEGORICAL } from '../models'
+import { MARKET_CATEGORICAL, MARKET_SCALAR, OutcomeRecord } from '../models'
 import marketReducer, { REDUCER_ID } from './market'
 import aMarket, { realData } from './market.builder'
 
@@ -22,7 +22,7 @@ describe('Market List Actions', () => {
   })
 
 
-  it('should return empty Immutable list when no markets are loaded', () => {
+  it('should return empty Immutable list when no markets are available', () => {
     // GIVEN
     const emptyResponse = { }
 
@@ -43,9 +43,32 @@ describe('Market List Actions', () => {
       .withTitle('How much will Cryptokitties transactions make up of the entire Ethereum network transactions by December 29th, in the last 1500 blocks?')
       .withDate('2017-12-30T00:00:00')
       .withVolume('9523809523809680')
-      .withType(MARKET_CATEGORICAL)
+      .withType(MARKET_SCALAR)
       .withOutcomes(undefined)
       .withBounds('1', '20', '%')
+      .get()
+
+    const aEthereumMarket = aMarket()
+      .withTitle('What will the number of Ethereum transactions be on January 3rd, 2018?')
+      .withDate('2018-01-03T12:00:00')
+      .withVolume('857142857142872776')
+      .withType(MARKET_SCALAR)
+      .withOutcomes(undefined)
+      .withBounds('500000', '1250000', 'Txs')
+      .get()
+
+    const gasOutcomes = List.of(
+      new OutcomeRecord({ name: '<20 GWei', marginalPrice: '0.2287' }),
+      new OutcomeRecord({ name: '20 GWei', marginalPrice: '0.3454' }),
+      new OutcomeRecord({ name: '>20 GWei', marginalPrice: '0.4259' }),
+    )
+    const aGasPriceMarket = aMarket()
+      .withTitle('What will be the median gas price on Feb. 1st, 2018?')
+      .withDate('2018-02-01T12:00:00')
+      .withVolume('342952380952380954')
+      .withType(MARKET_CATEGORICAL)
+      .withOutcomes(gasOutcomes)
+      .withBounds(undefined, undefined, undefined)
       .get()
 
     // WHEN
@@ -53,6 +76,10 @@ describe('Market List Actions', () => {
 
     // THEN
     const firstMarketRecord = store.getState().marketList.get(0)
+    const secondMarketRecord = store.getState().marketList.get(1)
+    const thirdMarketRecord = store.getState().marketList.get(2)
     expect(firstMarketRecord).toEqual(aKittiesMarket)
+    expect(secondMarketRecord).toEqual(aEthereumMarket)
+    expect(thirdMarketRecord).toEqual(aGasPriceMarket)
   })
 })

--- a/src/routes/marketlist/store/reducers/market.spec.js
+++ b/src/routes/marketlist/store/reducers/market.spec.js
@@ -1,4 +1,24 @@
+import { List } from 'immutable'
+import marketReducer from './market'
+import { MarketListRecord } from '../models'
+import { emptyMarkets } from './market.builder'
+import addMarkets from '../actions/addMarkets'
+
 describe('Market List Actions', () => {
+  it('should return the initial state when no markets are loaded', () => {
+    // GIVEN
+    const initialState = undefined
+    const marketAction = addMarkets(emptyMarkets())
+    const reduxState = marketReducer(initialState, marketAction)
+
+    const emptyListOfMarkets = List(emptyMarkets())
+
+    // WHEN
+    const emptyMarketListRecord = new MarketListRecord(emptyListOfMarkets)
+    // THEN
+    expect(reduxState).toEqual(emptyMarketListRecord)
+  })
+
   it('store Market records in store ', () => {
     expect(true).toEqual(true)
   })

--- a/src/routes/marketlist/store/reducers/market.spec.js
+++ b/src/routes/marketlist/store/reducers/market.spec.js
@@ -2,7 +2,9 @@ import { combineReducers, createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 import { List } from 'immutable'
 import { processMarketResponse } from '../actions/fetchMarkets'
+import { MARKET_CATEGORICAL } from '../models'
 import marketReducer, { REDUCER_ID } from './market'
+import aMarket, { realData } from './market.builder'
 
 describe('Market List Actions', () => {
   let store
@@ -33,7 +35,24 @@ describe('Market List Actions', () => {
     expect(marketListState).toEqual(emptyList)
   })
 
-  it('store Market records in store ', () => {
-    expect(true).toEqual(true)
+  it('store list of markets when API GET succeded', () => {
+    // GIVEN
+    const threeMarketsResponse = realData
+
+    const aKittiesMarket = aMarket()
+      .withTitle('How much will Cryptokitties transactions make up of the entire Ethereum network transactions by December 29th, in the last 1500 blocks?')
+      .withDate('2017-12-30T00:00:00')
+      .withVolume('9523809523809680')
+      .withType(MARKET_CATEGORICAL)
+      .withOutcomes(undefined)
+      .withBounds('1', '20', '%')
+      .get()
+
+    // WHEN
+    processMarketResponse(store.dispatch, threeMarketsResponse)
+
+    // THEN
+    const firstMarketRecord = store.getState().marketList.get(0)
+    expect(firstMarketRecord).toEqual(aKittiesMarket)
   })
 })

--- a/src/routes/marketlist/store/reducers/market.spec.js
+++ b/src/routes/marketlist/store/reducers/market.spec.js
@@ -2,9 +2,8 @@ import { combineReducers, createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 import { List } from 'immutable'
 import { processMarketResponse } from '../actions/fetchMarkets'
-import { MARKET_CATEGORICAL, MARKET_SCALAR, OutcomeRecord } from '../models'
 import marketReducer, { REDUCER_ID } from './market'
-import aMarket, { realData } from './market.builder'
+import { oneMarketData, twoMarketData, realData, MarketFactory } from './market.builder'
 
 describe('Market List Actions', () => {
   let store
@@ -39,38 +38,6 @@ describe('Market List Actions', () => {
     // GIVEN
     const threeMarketsResponse = realData
 
-    const aKittiesMarket = aMarket()
-      .withTitle('How much will Cryptokitties transactions make up of the entire Ethereum network transactions by December 29th, in the last 1500 blocks?')
-      .withDate('2017-12-30T00:00:00')
-      .withVolume('9523809523809680')
-      .withType(MARKET_SCALAR)
-      .withOutcomes(undefined)
-      .withBounds('1', '20', '%')
-      .get()
-
-    const aEthereumMarket = aMarket()
-      .withTitle('What will the number of Ethereum transactions be on January 3rd, 2018?')
-      .withDate('2018-01-03T12:00:00')
-      .withVolume('857142857142872776')
-      .withType(MARKET_SCALAR)
-      .withOutcomes(undefined)
-      .withBounds('500000', '1250000', 'Txs')
-      .get()
-
-    const gasOutcomes = List.of(
-      new OutcomeRecord({ name: '<20 GWei', marginalPrice: '0.2287' }),
-      new OutcomeRecord({ name: '20 GWei', marginalPrice: '0.3454' }),
-      new OutcomeRecord({ name: '>20 GWei', marginalPrice: '0.4259' }),
-    )
-    const aGasPriceMarket = aMarket()
-      .withTitle('What will be the median gas price on Feb. 1st, 2018?')
-      .withDate('2018-02-01T12:00:00')
-      .withVolume('342952380952380954')
-      .withType(MARKET_CATEGORICAL)
-      .withOutcomes(gasOutcomes)
-      .withBounds(undefined, undefined, undefined)
-      .get()
-
     // WHEN
     processMarketResponse(store.dispatch, threeMarketsResponse)
 
@@ -78,8 +45,27 @@ describe('Market List Actions', () => {
     const firstMarketRecord = store.getState().marketList.get(0)
     const secondMarketRecord = store.getState().marketList.get(1)
     const thirdMarketRecord = store.getState().marketList.get(2)
-    expect(firstMarketRecord).toEqual(aKittiesMarket)
-    expect(secondMarketRecord).toEqual(aEthereumMarket)
-    expect(thirdMarketRecord).toEqual(aGasPriceMarket)
+
+    expect(firstMarketRecord).toEqual(MarketFactory.aKittiesMarket)
+    expect(secondMarketRecord).toEqual(MarketFactory.aEthereumMarket)
+    expect(thirdMarketRecord).toEqual(MarketFactory.aGasPriceMarket)
+  })
+
+  it('replaces markets in store when fetch data', () => {
+    // GIVEN
+    const kittiesResponse = oneMarketData
+    processMarketResponse(store.dispatch, kittiesResponse)
+
+    // WHEN
+    const etherAndGasMarketsResponse = twoMarketData
+    processMarketResponse(store.dispatch, etherAndGasMarketsResponse)
+
+    // THEN
+    const firstMarketRecord = store.getState().marketList.get(0)
+    const secondMarketRecord = store.getState().marketList.get(1)
+
+    expect(store.getState().marketList.size).toEqual(2)
+    expect(firstMarketRecord).toEqual(MarketFactory.aEthereumMarket)
+    expect(secondMarketRecord).toEqual(MarketFactory.aGasPriceMarket)
   })
 })


### PR DESCRIPTION
**Due Diligence**
- [ ] Breaking change
- [x] Tests //JEST, Storybook, Chromatic components
- [ ] Documentation

**Description**
This PR creates the market list route (folders). Also, it includes the reducer and necessary actions for fetching, manipulate and store data (simplified) in the store. 

It includes tests based on features, using the "Builder" pattern. Those tests simulate a "real" redux store.

**DevNotes**
Additionally, it includes an update to Babel 7 and a simplified configuration for running tests on Travis.

The Builder pattern allows us to create markets in this way:
```
cons aEthereumMarket = aMarket()
    .withTitle('What will the number of Ethereum transactions be on January 3rd, 2018?')
    .withDate('2018-01-03T12:00:00')
    .withVolume('857142857142872776')
    .withType(MARKET_SCALAR)
    .withOutcomes()
    .withBounds('500000', '1250000', 'Txs')
    .get()
```
Which simplifies everything for following the GIVEN-WHEN-THEN approach.

**PM Notes**
This PR ticket is a subtask of PM-409