### PR TITLE
BUG: Fix failing estimateGas call

### DIFF
--- a/src/components/MarketDetail/index.js
+++ b/src/components/MarketDetail/index.js
@@ -71,8 +71,11 @@ class MarketDetail extends Component {
     this.props
       .fetchMarket()
       .then(() => {
-        this.props.requestGasCost(GAS_COST.REDEEM_WINNINGS, { eventAddress: this.props.market.event.address })
         this.props.fetchMarketTrades(this.props.market)
+
+        if (isMarketResolved(this.props.market)) {
+          this.props.requestGasCost(GAS_COST.REDEEM_WINNINGS, { eventAddress: this.props.market.event.address })
+        }
 
         if (firstFetch) {
           const availableView = this.getAvailableView()


### PR DESCRIPTION
We are calculating gas cost every time on market detail page, regardless of whether the market is resolved or not. When the market is not resolved, it would raise this error: 
```
Error: gas required exceeds allowance or always failing transaction
```
The reason for this is in smart contract function redeemWinnigs:
```
function redeemWinnings()
        public
        returns (uint winnings)
    {
        // Winning outcome has to be set
        ➡️require(isOutcomeSet);
        // Calculate winnings
        winnings = outcomeTokens[uint(outcome)].balanceOf(msg.sender);
        // Revoke tokens from winning outcome
        outcomeTokens[uint(outcome)].revoke(msg.sender, winnings);
        // Payout winnings
        require(collateralToken.transfer(msg.sender, winnings));
        WinningsRedemption(msg.sender, winnings);
    }
```

Since outcome was not set, the simulated transaction will fail