### PR TITLE
Enable strict path case checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "babel-preset-stage-0": "6.24.1",
     "bootstrap-loader": "^2.1.0",
     "bootstrap-sass": "^3.3.7",
+    "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "css-loader": "^0.28.9",
     "eslint": "^4.17.0",
     "eslint-config-airbnb": "^16.1.0",

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,5 +1,6 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
 
 const path = require('path')
 const webpack = require('webpack')
@@ -92,6 +93,7 @@ module.exports = {
     },
   },
   plugins: [
+    new CaseSensitivePathsPlugin(),
     new FaviconsWebpackPlugin({
       logo: 'assets/img/gnosis_logo_favicon.png',
       // Generate a cache file with control hashes and


### PR DESCRIPTION
We ran into errors with different filename casing. e.g. `header.scss` being imported as `./Header.scss`. This works on OSX, but not on other unix environments, causing errors we can't foresee.

Enables a plugin that will not allow you to import a file if the casing is mismatched. Not enabled in production, because we only develop with webpack.dev configuration, don't want additional overhead during compile for prod.