### PR TITLE
Change the way to identify metamask

### DIFF
--- a/src/integrations/metamask/index.js
+++ b/src/integrations/metamask/index.js
@@ -30,7 +30,8 @@ class Metamask extends InjectedWeb3 {
     try {
       if (
         typeof window.web3 !== 'undefined' &&
-        window.web3.currentProvider.isMetaMask
+        (window.web3.currentProvider.constructor.name === 'MetamaskInpageProvider' ||
+          window.web3.currentProvider.isMetaMask)
       ) {
         this.web3 = new Web3(window.web3.currentProvider)
         window.web3 = this.web3

--- a/src/integrations/metamask/index.js
+++ b/src/integrations/metamask/index.js
@@ -30,7 +30,7 @@ class Metamask extends InjectedWeb3 {
     try {
       if (
         typeof window.web3 !== 'undefined' &&
-        window.web3.currentProvider.constructor.name === 'MetamaskInpageProvider'
+        window.web3.currentProvider.isMetaMask
       ) {
         this.web3 = new Web3(window.web3.currentProvider)
         window.web3 = this.web3


### PR DESCRIPTION
Previously we used to check `window.web3.currentProvider.constructor.name === 'MetamaskInpageProvider'`
With metamask v4, constructor got minified and now the name is `f`, don't know is the change was planned but I think relying on a bool variable inside the provider is better than on a constructor's name.
https://github.com/MetaMask/metamask-extension/issues/3372

**QUESTION**:
Should we use both ways? 
```
(window.web3.currentProvider.constructor.name === 'MetamaskInpageProvider' || window.web3.currentProvider.isMetaMask)
```