### PR TITLE
Task: Fix Form Issues

### DIFF
--- a/src/components/Form/InputError.mod.scss
+++ b/src/components/Form/InputError.mod.scss
@@ -1,6 +1,7 @@
 @import "../../scss/vars.scss";
 
 .inputError {
+  position: absolute;
   font-weight: 800;
   color: $active-highlight-error;
   padding: $paddings-inputs;

--- a/src/components/Form/OutcomeSelection.mod.scss
+++ b/src/components/Form/OutcomeSelection.mod.scss
@@ -1,4 +1,18 @@
-@import "../../../scss/vars.scss";
+@import "../../scss/vars.scss";
+
+.formOutcomeSelection {
+  width: 100%;
+
+  &.hideBars {
+    .wrapper {
+      padding-left: 10px;
+
+      .outcomeBar {
+        display: none;
+      }
+    }
+  }
+}
 
 .outcome {
   margin: 5px 0;

--- a/src/components/Form/OutcomeSelection/OutcomeBar.js
+++ b/src/components/Form/OutcomeSelection/OutcomeBar.js
@@ -5,7 +5,7 @@ import classNames from 'classnames/bind'
 import { decimalToText } from 'components/DecimalValue'
 import Decimal from 'decimal.js'
 
-import css from './OutcomeBar.mod.scss'
+import css from '../OutcomeSelection.mod.scss'
 
 const cx = classNames.bind(css)
 

--- a/src/components/Form/OutcomeSelection/index.js
+++ b/src/components/Form/OutcomeSelection/index.js
@@ -7,16 +7,18 @@ import classNames from 'classnames/bind'
 
 import OutcomeBar from './OutcomeBar'
 
-import css from './style.mod.scss'
+import css from '../OutcomeSelection.mod.scss'
 
 const cx = classNames.bind(css)
 
 class OutcomeSelection extends PureComponent {
   render() {
-    const { outcomes, label, input: { value, onChange } } = this.props
+    const {
+      outcomes, label, hideBars, input: { value, onChange },
+    } = this.props
 
     return (
-      <div className={cx('formOutcomeSelection')}>
+      <div className={cx('formOutcomeSelection', { hideBars })}>
         <label>{label}</label>
         {outcomes.map(outcome => (<OutcomeBar
           {...outcome}
@@ -31,6 +33,7 @@ class OutcomeSelection extends PureComponent {
 
 OutcomeSelection.propTypes = {
   input: PropTypes.shape(fieldPropTypes.input).isRequired,
+  hideBars: PropTypes.bool,
   outcomes: PropTypes.arrayOf(PropTypes.shape({
     probability: PropTypes.instanceOf(Decimal).isRequired,
     index: PropTypes.number.isRequired,
@@ -41,6 +44,7 @@ OutcomeSelection.propTypes = {
 }
 
 OutcomeSelection.defaultProps = {
+  hideBars: false,
   outcomes: [],
   label: '',
 }

--- a/src/components/Form/OutcomeSelection/style.mod.scss
+++ b/src/components/Form/OutcomeSelection/style.mod.scss
@@ -1,3 +1,0 @@
-.formOutcomeSelection {
-  width: 100%;
-}

--- a/src/components/Form/TextInput.js
+++ b/src/components/Form/TextInput.js
@@ -15,6 +15,7 @@ const TextInput = ({
   type,
   className,
   placeholder,
+  decoration,
   meta: { touched, error },
   startAdornment,
   endAdornment,
@@ -22,7 +23,7 @@ const TextInput = ({
 }) => {
   const inputId = `formTextInput_${input.name}`
 
-  const textInputClasses = cx('formTextInput', className, {
+  const textInputClasses = cx('formTextInput', className, decoration, {
     error: (touched && error),
   })
 
@@ -57,6 +58,7 @@ TextInput.propTypes = {
   placeholder: PropTypes.string,
   startAdornment: PropTypes.node,
   endAdornment: PropTypes.node,
+  decoration: PropTypes.oneOf(['underlined']),
 }
 
 TextInput.defaultProps = {
@@ -66,6 +68,7 @@ TextInput.defaultProps = {
   placeholder: '',
   startAdornment: undefined,
   endAdornment: undefined,
+  decoration: undefined,
 }
 
 export default TextInput

--- a/src/components/Form/TextInput.mod.scss
+++ b/src/components/Form/TextInput.mod.scss
@@ -9,6 +9,14 @@
 }
 
 .formTextInput {
+  &.underlined {
+    input {
+      border-color: $font-color-light;
+      border-bottom-style: dotted;
+      border-bottom-width: 2px;
+    }
+  }
+
   input {
     -webkit-appearance: none !important;
     border: none;

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/OutcomesSection/OutcomeSectionScalar/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/OutcomesSection/OutcomeSectionScalar/index.js
@@ -59,7 +59,7 @@ const OutcomeSectionScalar = (props) => {
       <div className={cn('row')}>
         <div className={cn('col-md-12')}>
           <h2>Your Trade</h2>
-          <Field component={OutcomeSelection} name="selectedOutcome" outcomes={scalarOutcomes} />
+          <Field component={OutcomeSelection} name="selectedOutcome" outcomes={scalarOutcomes} hideBars />
         </div>
       </div>
       <div className={cn('row')}>

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/index.js
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/index.js
@@ -156,6 +156,7 @@ class MarketBuySharesForm extends Component {
                     name="invest"
                     component={TextInput}
                     className={cx('marketBuyInvest')}
+                    decoration="underlined"
                     placeholder="Investment"
                     validate={this.validateInvestment}
                     endAdornment={

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/marketBuySharesForm.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/marketBuySharesForm.mod.scss
@@ -36,10 +36,6 @@
     &:placeholder {
       font-weight: 300;
     }
-
-    border-color: $bg-color-dark;
-    border-bottom-style: dotted;
-    border-bottom-width: 2px;
   }
 }
 


### PR DESCRIPTION
Thanks to Mikhail for pointing out these issues:


- TextInput now has a `decoration` prop where you can pass `underlined` and it will have that dotted underline that we used everywhere
- Updated the OutcomeSelection to have a `hideBars` prop to disable the actual outcome probability bars on scalar markets

- I didn’t change the slider, I think it looks better this way, the previous version was more inconsistent across the screens, the `light` version of the scalar is supposed to look like this imo, otherwise let's change this in the design overhaul