### PR TITLE
Task: Fix CollateralToken issues on non-tournament mode

### DIFF
--- a/src/actions/blockchain.js
+++ b/src/actions/blockchain.js
@@ -70,7 +70,7 @@ export const initGnosis = () => async (dispatch, getState) => {
       await initGnosisConnection(opts)
       await dispatch(setGnosisInitialized({ initialized: true }))
 
-      if (newProvider.account) {
+      if (newProvider.account && collateralToken) {
         await getTokenBalance(collateralToken.address, await getCurrentAccount())
       }
     }

--- a/src/components/Dashboard/index.js
+++ b/src/components/Dashboard/index.js
@@ -22,7 +22,7 @@ import {
 import moment from 'moment'
 import Decimal from 'decimal.js'
 import { EXPAND_MY_SHARES } from 'routes/MarketDetails/components/ExpandableViews'
-import { isFeatureEnabled } from 'utils/features'
+import { isFeatureEnabled, get } from 'utils/features'
 
 import Metrics from './Metrics'
 import './dashboard.scss'
@@ -40,7 +40,7 @@ const getSoonClosingMarkets = (markets = [], limit) =>
 
 class Dashboard extends Component {
   componentDidMount() {
-    if (!this.props.tokenSymbol) {
+    if (!this.props.collateralToken.symbol) {
       this.props.requestTokenSymbol()
     }
 
@@ -56,7 +56,10 @@ class Dashboard extends Component {
       if (this.props.hasWallet) {
         this.props.requestAccountShares(this.props.defaultAccount)
         this.props.requestAccountTrades(this.props.defaultAccount)
-        this.props.requestDefaultTokenAmount(this.props.defaultAccount)
+
+        if (this.props.collateralToken.address) {
+          this.props.requestDefaultTokenAmount(this.props.collateralToken.address, this.props.defaultAccount)
+        }
       }
     }
 
@@ -324,13 +327,13 @@ class Dashboard extends Component {
 
   render() {
     const {
-      hasWallet, defaultTokenAmount, accountPredictiveAssets, tokenSymbol, tokenIcon,
+      hasWallet, collateralToken, accountPredictiveAssets,
     } = this.props
     let metricsSection = <div />
     let tradesHoldingsSection = <div className="dashboardWidgets dashboardWidgets--financial" />
     const predictedProfitFormatted = Decimal(accountPredictiveAssets).toDP(4, 1).toString()
     if (hasWallet) {
-      metricsSection = <Metrics tokens={defaultTokenAmount} tokenSymbol={tokenSymbol} tokenIcon={tokenIcon} predictedProfit={predictedProfitFormatted} />
+      metricsSection = <Metrics tokens={collateralToken.amount} tokenSymbol={collateralToken.symbol} tokenIcon={collateralToken.icon} predictedProfit={predictedProfitFormatted} />
 
       tradesHoldingsSection = (
         <div className="dashboardWidgets dashboardWidgets--financial">
@@ -391,18 +394,22 @@ Dashboard.propTypes = {
   changeUrl: PropTypes.func.isRequired,
   requestDefaultTokenAmount: PropTypes.func.isRequired,
   gnosisInitialized: PropTypes.bool.isRequired,
-  redeemWinnings: PropTypes.func,
+  redeemWinnings: PropTypes.func.isRequired,
   accountPredictiveAssets: PropTypes.string.isRequired,
-  defaultTokenAmount: PropTypes.string.isRequired,
-  tokenSymbol: PropTypes.string,
-  tokenIcon: PropTypes.string.isRequired,
   requestTokenSymbol: PropTypes.func.isRequired,
   fetchTournamentUsers: PropTypes.func.isRequired,
   fetchTournamentUserData: PropTypes.func.isRequired,
+  collateralToken: PropTypes.shape({
+    symbol: PropTypes.string,
+    amount: PropTypes.string,
+    address: PropTypes.string,
+  }).isRequired,
 }
 
 Dashboard.defaultProps = {
-  tokenSymbol: '',
+  markets: [],
+  defaultAccount: undefined,
+  accountShares: {},
 }
 
 export default Dashboard

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -188,7 +188,7 @@ Header.propTypes = {
   showGameGuide: PropTypes.bool,
   gameGuideType: PropTypes.string,
   gameGuideURL: PropTypes.string,
-  tokenAddress: PropTypes.string.isRequired,
+  tokenAddress: PropTypes.string,
   lockedMetamask: PropTypes.bool,
   requestMainnetAddress: PropTypes.func.isRequired,
   requestTokenBalance: PropTypes.func.isRequired,
@@ -211,6 +211,7 @@ Header.defaultProps = {
   mainnetAddress: undefined,
   lockedMetamask: true,
   userTournamentInfo: undefined,
+  tokenAddress: undefined,
 }
 
 export default Header

--- a/src/components/Outcome/index.js
+++ b/src/components/Outcome/index.js
@@ -47,7 +47,7 @@ const Outcome = ({
     />
   )
 
-  if (showWinningOutcome) {
+  if (showWinningOutcome && winningOutcome) {
     outcomeComponent = (
       <WinningOutcome
         type={type}

--- a/src/containers/DashboardPage/index.js
+++ b/src/containers/DashboardPage/index.js
@@ -6,15 +6,13 @@ import { getMarkets } from 'selectors/market'
 import { profitsSelector } from 'containers/DashboardPage/store/selectors'
 import { getAccountTrades } from 'selectors/marketTrades'
 import { getAccountShares } from 'selectors/marketShares'
-import { isGnosisInitialized, getTokenAmount, getTokenSymbol } from 'selectors/blockchain'
+import { isGnosisInitialized, getCollateralTokenAmount } from 'selectors/blockchain'
 import { getCurrentAccount, checkWalletConnection } from 'integrations/store/selectors'
 import { requestMarkets, requestAccountTrades, requestAccountShares, redeemWinnings } from 'actions/market'
 import { requestGasPrice, requestTokenBalance, requestTokenSymbol } from 'actions/blockchain'
 import { weiToEth } from 'utils/helpers'
 import { fetchTournamentUserData, fetchTournamentUsers } from 'routes/Scoreboard/store/actions'
-import { getCollateralToken } from 'utils/features'
 
-const collateralToken = getCollateralToken()
 
 const mapStateToProps = (state) => {
   const markets = getMarkets(state)
@@ -23,28 +21,18 @@ const mapStateToProps = (state) => {
   const accountPredictiveAssets = weiToEth(profitsSelector(state, defaultAccount))
   const accountShares = getAccountShares(state)
   const gnosisInitialized = isGnosisInitialized(state)
-  let defaultTokenAmount = getTokenAmount(state, collateralToken.address)
   const hasWallet = checkWalletConnection(state)
-  const tokenSymbol = getTokenSymbol(state, collateralToken.address)
-
-  if (defaultTokenAmount !== undefined) {
-    defaultTokenAmount = weiToEth(defaultTokenAmount.toString())
-  } else {
-    defaultTokenAmount = '0'
-  }
+  const collateralToken = getCollateralTokenAmount(state)
 
   return {
     hasWallet,
     defaultAccount,
     markets,
-    defaultTokenAmount,
     accountShares,
     accountTrades,
     gnosisInitialized,
     accountPredictiveAssets,
-    tokenSymbol,
-    tokenAddress: collateralToken.address,
-    tokenIcon: collateralToken.icon,
+    collateralToken,
   }
 }
 
@@ -55,8 +43,8 @@ const mapDispatchToProps = dispatch => ({
   requestAccountShares: address => dispatch(requestAccountShares(address)),
   changeUrl: url => dispatch(push(url)),
   requestGasPrice: () => dispatch(requestGasPrice()),
-  requestDefaultTokenAmount: account => dispatch(requestTokenBalance(collateralToken.address, account)),
-  requestTokenSymbol: () => dispatch(requestTokenSymbol(collateralToken.address)),
+  requestDefaultTokenAmount: (address, account) => dispatch(requestTokenBalance(address, account)),
+  requestTokenSymbol: address => dispatch(requestTokenSymbol(address)),
   fetchTournamentUsers: () => dispatch(fetchTournamentUsers()),
   fetchTournamentUserData: account => dispatch(fetchTournamentUserData(account)),
 })

--- a/src/containers/DashboardPage/index.js
+++ b/src/containers/DashboardPage/index.js
@@ -6,7 +6,7 @@ import { getMarkets } from 'selectors/market'
 import { profitsSelector } from 'containers/DashboardPage/store/selectors'
 import { getAccountTrades } from 'selectors/marketTrades'
 import { getAccountShares } from 'selectors/marketShares'
-import { isGnosisInitialized, getCollateralTokenAmount } from 'selectors/blockchain'
+import { isGnosisInitialized, getCollateralTokenInfo } from 'selectors/blockchain'
 import { getCurrentAccount, checkWalletConnection } from 'integrations/store/selectors'
 import { requestMarkets, requestAccountTrades, requestAccountShares, redeemWinnings } from 'actions/market'
 import { requestGasPrice, requestTokenBalance, requestTokenSymbol } from 'actions/blockchain'
@@ -22,7 +22,7 @@ const mapStateToProps = (state) => {
   const accountShares = getAccountShares(state)
   const gnosisInitialized = isGnosisInitialized(state)
   const hasWallet = checkWalletConnection(state)
-  const collateralToken = getCollateralTokenAmount(state)
+  const collateralToken = getCollateralTokenInfo(state)
 
   return {
     hasWallet,

--- a/src/containers/HeaderContainer/store/selectors.js
+++ b/src/containers/HeaderContainer/store/selectors.js
@@ -32,9 +32,7 @@ const logoConfig = getLogoConfig('logo')
  * @param {*} state
  */
 const getCurrentTokenBalance = (state) => {
-  const platformToken = collateralToken.address
-
-  if (!platformToken) {
+  if (!collateralToken) {
     return getCurrentBalance(state)
   }
 
@@ -63,7 +61,7 @@ export default state => ({
   showGameGuide: isFeatureEnabled('gameGuide'),
   gameGuideType: gameGuideConfig.type,
   gameGuideURL: gameGuideConfig.url,
-  tokenAddress: collateralToken.address,
+  tokenAddress: collateralToken && collateralToken.address,
   tokenBalance: getCurrentTokenBalance(state),
 })
 

--- a/src/selectors/blockchain.js
+++ b/src/selectors/blockchain.js
@@ -1,4 +1,9 @@
 import Decimal from 'decimal.js'
+import { getCollateralToken } from 'utils/features'
+import { getCurrentBalance } from 'integrations/store/selectors'
+import { weiToEth } from 'utils/helpers'
+
+const ETH_TOKEN_ICON = 'assets/img/icons/icon_etherTokens.svg'
 
 /**
  * Returns if gnosis.js is initialized or not
@@ -23,3 +28,27 @@ export const getTokenAmount = (state, tokenAddress) => {
 }
 
 export const getTokenSymbol = (state, tokenAddress) => state.blockchain.getIn(['tokenSymbols', tokenAddress])
+
+/**
+ * @param {*} state - redux state
+ * @returns {object} collateralToken - with Symbol, Amount in ETH and Address
+ */
+export const getCollateralTokenAmount = (state) => {
+  const collateralToken = getCollateralToken()
+
+  if (!collateralToken) {
+    return {
+      symbol: 'ETH',
+      amount: weiToEth(getCurrentBalance(state)),
+      address: undefined,
+      icon: ETH_TOKEN_ICON,
+    }
+  }
+
+  return {
+    symbol: getTokenSymbol(state, collateralToken.address),
+    amount: weiToEth(getTokenAmount(state, collateralToken.address)),
+    address: collateralToken.address,
+    icon: collateralToken.icon,
+  }
+}

--- a/src/selectors/blockchain.js
+++ b/src/selectors/blockchain.js
@@ -33,7 +33,7 @@ export const getTokenSymbol = (state, tokenAddress) => state.blockchain.getIn(['
  * @param {*} state - redux state
  * @returns {object} collateralToken - with Symbol, Amount in ETH and Address
  */
-export const getCollateralTokenAmount = (state) => {
+export const getCollateralTokenInfo = (state) => {
   const collateralToken = getCollateralToken()
 
   if (!collateralToken) {


### PR DESCRIPTION
CollateralToken is now an object that can be requested using the selector in /selectors/blockchain. It returns the collateralTokens symbol, amount in ETH, icon and address