### PR TITLE
Task PM-586: Use CSS modules in components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -21,8 +21,8 @@
         [
           "transform-react-remove-prop-types",
           {
-            "mode": "remove",
-            "removeImport": true
+            "removeImport": true,
+            "additionalLibraries": ["react-immutable-proptypes"]
           }
         ]
       ]

--- a/config/environments/local/config.json
+++ b/config/environments/local/config.json
@@ -1,7 +1,7 @@
 {
   "gnosisdb": {
     "protocol": "https",
-    "host": "gnosisdb.dev.gnosisdev.com",
+    "host": "gnosisdb.staging.gnosisdev.com",
     "port": 443
   },
   "ethereum": {

--- a/src/components/TransactionFloater/index.js
+++ b/src/components/TransactionFloater/index.js
@@ -1,16 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cn from 'classnames/bind'
 import { NavLink } from 'react-router-dom'
 import { takeRight } from 'lodash'
-
 import moment from 'moment'
-
 import LabeledSpinner from 'components/Spinner/Labeled'
 import ProgressSpinner from 'components/Spinner/Transaction'
 import Notifications from 'components/Notifications'
+import Icon from 'components/Icon'
 import { TRANSACTION_COMPLETE_STATUS } from 'utils/constants'
+import style from './transactionFloater.mod.scss'
 
-import './transactionFloater.scss'
+const cx = cn.bind(style)
 
 const TransactionFloater = ({
   progress,
@@ -21,11 +22,8 @@ const TransactionFloater = ({
   hideTransactionLog,
   showTransactionLog,
 }) => (
-  <div className="transactionFloater">
-    <button
-      className="transactionFloater__spinner"
-      onClick={() => (showLogs ? hideTransactionLog() : showTransactionLog())}
-    >
+  <div className={cx('transactionFloater')}>
+    <button className={cx('spinner')} onClick={() => (showLogs ? hideTransactionLog() : showTransactionLog())}>
       <LabeledSpinner
         width={32}
         height={32}
@@ -41,23 +39,19 @@ const TransactionFloater = ({
     </button>
     {!showLogs &&
       notifications.length > 0 && (
-      <div className="transactionFloater__popover transactionFloater--notifications">
+      <div className={cx('popover', 'notifications')}>
         <Notifications notifications={takeRight(notifications, 5)} onClick={showTransactionLog} />
       </div>
     )}
-    <div
-      className={`transactionFloater__popover ${
-        showLogs ? 'transactionFloater__popover--visible' : 'transactionFloater__popover--hidden'
-      }`}
-    >
-      <div className="transactionFloater__heading">Transactions</div>
-      <div className="transactionFloater__close" onClick={() => hideTransactionLog()} />
-      <div className="transactionFloater__logs">
+    <div className={cx('popover', showLogs ? 'visible' : 'hidden')}>
+      <div className={cx('heading')}>Transactions</div>
+      <button className={cx('closeButton')} onClick={() => hideTransactionLog()} />
+      <div className={cx('logs')}>
         {!runningTransactions.length &&
           !completedTransactions.length && (
-          <div className="transactionLog transactionLog--empty">
-            <div className="transactionLog__label">You have no active or past transactions.</div>
-            <div className="transactionLog__hint">
+          <div className={cx('transactionLog', 'empty')}>
+            <div className={cx('label')}>You have no active or past transactions.</div>
+            <div className={cx('hint')}>
                 When you interact with markets, all transactions will show up down here so you can keep track of all
                 your purchases, investments and market interactions.
             </div>
@@ -67,8 +61,8 @@ const TransactionFloater = ({
           const startTime = transaction.startTime ? moment(transaction.startTime).format('LLL') : ''
 
           return (
-            <div key={transaction.id} className="transactionLog">
-              <div className="transactionLog__progress">
+            <div key={transaction.id} className={cx('transactionLog')}>
+              <div className={cx('progress')}>
                 <ProgressSpinner
                   width={16}
                   height={16}
@@ -78,8 +72,8 @@ const TransactionFloater = ({
                   modifier="spinning"
                 />
               </div>
-              <div className="transactionLog__label">{transaction.label || 'Unnamed Transaction'}</div>
-              <div className="transactionLog__startTime">{startTime}</div>
+              <div className={cx('label')}>{transaction.label || 'Unnamed Transaction'}</div>
+              <div className={cx('startTime')}>{startTime}</div>
             </div>
           )
         })}
@@ -92,17 +86,17 @@ const TransactionFloater = ({
 
           const icon = transaction.completionStatus === TRANSACTION_COMPLETE_STATUS.NO_ERROR ? 'checkmark' : 'error'
           return (
-            <div key={transaction.id} className="transactionLog">
-              <div className={`transactionLog__progressIcon icon icon--${icon}`} />
-              <div className="transactionLog__label">{transaction.label || 'Unnamed Transaction'}</div>
-              <div className="transactionLog__startTime">
+            <div key={transaction.id} className={cx('transactionLog')}>
+              <Icon type={icon} className={cx('progressIcon')} />
+              <div className={cx('label')}>{transaction.label || 'Unnamed Transaction'}</div>
+              <div className={cx('startTime')}>
                 {endTime} {timeDiff && `(took ${timeDiff})`}
               </div>
             </div>
           )
         })}
       </div>
-      <div className="transactionFloater__footer">
+      <div className={cx('footer')}>
         <NavLink to="/transactions" onClick={hideTransactionLog}>
           Show all transactions
         </NavLink>

--- a/src/components/TransactionFloater/index.js
+++ b/src/components/TransactionFloater/index.js
@@ -106,13 +106,20 @@ const TransactionFloater = ({
 )
 
 TransactionFloater.propTypes = {
-  progress: PropTypes.number,
+  progress: PropTypes.number.isRequired,
   runningTransactions: PropTypes.arrayOf(PropTypes.object),
   completedTransactions: PropTypes.arrayOf(PropTypes.object),
   notifications: PropTypes.arrayOf(PropTypes.object),
   showLogs: PropTypes.bool,
-  hideTransactionLog: PropTypes.func,
-  showTransactionLog: PropTypes.func,
+  hideTransactionLog: PropTypes.func.isRequired,
+  showTransactionLog: PropTypes.func.isRequired,
+}
+
+TransactionFloater.defaultProps = {
+  notifications: [],
+  runningTransactions: [],
+  completedTransactions: [],
+  showLogs: false,
 }
 
 export default TransactionFloater

--- a/src/components/TransactionFloater/transactionFloater.mod.scss
+++ b/src/components/TransactionFloater/transactionFloater.mod.scss
@@ -23,21 +23,22 @@ $shadow-color: #828282;
 
   z-index: 1000;
 
-  &__heading {
+  .heading {
     text-align: center;
     font-size: 12px;
     text-transform: uppercase;
     padding-top: 16px;
   }
 
-  &__close {
+  .closeButton {
     @include closeButton(12px, 2px);
 
-    top: 12px;
-    right: 7px;
+    top: 7px;
+    right: 12px;
+    border: none;
   }
 
-  &__spinner {
+  .spinner {
     z-index: 1001;
     cursor: pointer;
     filter: drop-shadow(0px 0px 6px lighten($shadow-color, 20%));
@@ -49,7 +50,7 @@ $shadow-color: #828282;
     }
   }
 
-  &__popover {
+  .popover {
     position: absolute;
     bottom: 100%;
     margin-bottom: $expandable-arrow-margin;
@@ -60,16 +61,16 @@ $shadow-color: #828282;
     background-color: $floater-bg;
     filter: drop-shadow(0 0 4px $shadow-color);
 
-    &--visible {
+    &.visible {
       opacity: 1;
     }
 
-    &--hidden {
+    &.hidden {
       opacity: 0;
       pointer-events: none;
     }
 
-    transition: opacity .4s ease;
+    transition: opacity 0.4s ease;
 
     &::after {
       content: '';
@@ -83,20 +84,18 @@ $shadow-color: #828282;
       border-right: $expandable-arrow-size solid transparent;
       border-top: $expandable-arrow-size solid $floater-bg-bottom;
     }
-
   }
 
-  &--notifications {
+  .notifications {
     padding-bottom: 0;
     background-color: transparent;
   }
 
-
-  &__logs {
+  .logs {
     padding: 8px 0;
   }
 
-  &__footer {
+  .footer {
     position: absolute;
     padding: 12px 0;
     border-bottom-left-radius: 4px;
@@ -109,57 +108,57 @@ $shadow-color: #828282;
     background-color: $floater-bg-bottom;
     text-align: center;
   }
-}
 
-.transactionLog {
-  padding: 4px 0;
-  margin-right: 12px;
-  margin-left: 38px;
-  position: relative;
+  .transactionLog {
+    padding: 4px 0;
+    margin-right: 12px;
+    margin-left: 38px;
+    position: relative;
 
-  &--empty {
-    margin: 0px;
-    
-    .transactionLog__label {
-      text-align: center;
+    &.empty {
+      margin: 0px;
+
+      .label {
+        text-align: center;
+      }
+
+      .hint {
+        margin: 12px;
+        text-align: center;
+        color: $font-color-muted;
+      }
     }
 
-    .transactionLog__hint {
-      margin: 12px;
-      text-align: center;
+    &:not(:last-of-type) {
+      border-bottom: 1px solid $floater-bg-bottom;
+    }
+
+    .label {
+      font-weight: 500;
+      margin: 8px 0;
+    }
+
+    .startTime {
+      text-transform: uppercase;
       color: $font-color-muted;
     }
-  }
 
-  &:not(:last-of-type) {
-    border-bottom: 1px solid $floater-bg-bottom;
-  }
+    .progress {
+      position: absolute;
+      top: 10px;
+      margin-right: 4px;
+      right: 100%;
+    }
 
-  &__label {
-    font-weight: 500;
-    margin: 8px 0;
-  }
+    .progressIcon {
+      position: absolute;
+      top: 10px;
+      margin-right: 4px;
+      right: 100%;
+    }
 
-  &__startTime {
-    text-transform: uppercase;
-    color: $font-color-muted;
-  }
-
-  &__progress {
-    position: absolute;
-    top: 10px;
-    margin-right: 4px;
-    right: 100%;
-  }
-
-  &__progressIcon {
-    position: absolute;
-    top: 10px;
-    margin-right: 4px;
-    right: 100%;
-  }
-
-  .icon {
-    position: absolute;
+    .icon {
+      position: absolute;
+    }
   }
 }

--- a/src/containers/TransactionFloaterContainer/index.js
+++ b/src/containers/TransactionFloaterContainer/index.js
@@ -3,10 +3,7 @@ import { takeRight } from 'lodash'
 
 import TransactionFloater from 'components/TransactionFloater'
 
-import {
-  showTransactionLog,
-  hideTransactionLog,
-} from 'actions/transactions'
+import { showTransactionLog, hideTransactionLog } from 'actions/transactions'
 
 import {
   getRunningTransactions,
@@ -15,9 +12,7 @@ import {
   areLogsVisible,
 } from 'selectors/transactions'
 
-import {
-  getVisibleNotifications,
-} from 'selectors/notifications'
+import { getVisibleNotifications } from 'selectors/notifications'
 
 const LIMIT_COUNT_RUNNING_TRANSACTIONS = 3
 const LIMIT_COUNT_COMPLETED_TRANSACTIONS = 3

--- a/src/routes/MarketList/components/NoMarkets/index.js
+++ b/src/routes/MarketList/components/NoMarkets/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 
 const NoMarkets = () => (
-  <div className="marketListContainer">
-    <div className="market no-markets">No Markets available</div>
+  <div>
+    <p>No Markets available</p>
   </div>
 )
 


### PR DESCRIPTION
### Description
* `Transaction floater` component is using css modules now
* Added `react-immutable-proptypes` to babel plugin which deletes PropTypes in production
* Made local config use staging gnosisDB
### Which Tickets does my PR fix? 
* task/PM-586
### Which side effects could my PR have?
* Styling bugs
### Which Steps did I take to verify my PR?
- Compared TransactionFloater to previous version, everything looked OK