### PR TITLE
Task: Fix Tests, Fix verbose console.log for GNOSIS_ENV

### DIFF
--- a/configuration.js
+++ b/configuration.js
@@ -17,7 +17,7 @@ module.exports = (env, envVarsConfig = {}, envVarsInterface = {}) => {
   if (!isValidConfigFolder) {
     console.warn(`[WEBPACK]: invalid interface configuration selected: '${env}' - using fallback configuration`)
   } else {
-    console.info(`[WEBPACK]: loaded env configuration: '${env}'`)
+    // console.info(`[WEBPACK]: loaded env configuration: '${env}'`)
     configsToLoad.push(envConfigFolder)
   }
 

--- a/configuration.setup.js
+++ b/configuration.setup.js
@@ -1,6 +1,9 @@
 const configLoader = require('./configuration')
 
-const { config, interfaceConfig } = configLoader('local')
+const ENV = 'local'
+
+console.info(`[JEST]: using env configuration: '${ENV}'`)
+const { config, interfaceConfig } = configLoader(ENV)
 window.GNOSIS_CONFIG = config
 window.GNOSIS_INTERFACE = interfaceConfig
 

--- a/src/routes/MarketList/store/test/newMarkets.selector.js
+++ b/src/routes/MarketList/store/test/newMarkets.selector.js
@@ -42,7 +42,7 @@ const newMarketsTests = () => {
       // GIVEN
       const aClosedMarket = aMarket()
         .ofScalarType()
-        .withResolution(moment().subtract(1, 'M'))
+        .withResolution(moment().subtract(3, 'days'))
         .withStage(MARKET_STAGES.MARKET_CLOSED)
         .get()
 

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -14,6 +14,8 @@ module.exports = (env = {}) => {
   const interfaceEnvVars = env.GNOSIS_INTERFACE || {}
 
   const gnosisEnv = env.GNOSIS_ENV || 'local'
+
+  console.info(`[WEBPACK-DEV]: using env configuration: '${gnosisEnv}'`)
   const { config, interfaceConfig } = configLoader(gnosisEnv, configEnvVars, interfaceEnvVars)
 
   const version = env.BUILD_VERSION || pkg.version

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -17,6 +17,8 @@ module.exports = (env = {}) => {
   const interfaceEnvVars = env.GNOSIS_INTERFACE || {}
 
   const gnosisEnv = process.env.GNOSIS_ENV || 'development'
+
+  console.info(`[WEBPACK-PROD]: using env configuration: '${gnosisEnv}'`)
   const { config, interfaceConfig } = configLoader(gnosisEnv, configEnvVars, interfaceEnvVars)
 
   return {


### PR DESCRIPTION
### Description
* GNOSIS_ENV will only be output once
* Tests won't fail randomly anymore

### Which Tickets does my PR fix? (Put in title too)
* /

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* /

### Which Steps did I take to verify my PR?

*Testcases Failing*
* Ran Tests multiple times

*Verbose `console.info`*
* Ran tests and built prod and dev, both with only one notice of the GNOSIS_ENV

### Background Information
* Tests were using a resolution day of `today - 1 M` (which should be 1 month) this is actually not documented to be working at all, so it must've used something else which caused the tests to fail from time to time. Replaced it with `3 'days'` 

### Configuration Entries
* /