### PR TITLE
PM-445: Implemented configurable gasPrice Source (ETH Gasstation)

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -9,5 +9,11 @@
     "host": "rinkeby.infura.io",
     "port": 443
   },
+  "gasPrice": {
+    "external": {
+      "url": "https://ethgasstation.info/json/ethgasAPI.json",
+      "type": "ETH_GAS_STATION"
+    }
+  },
   "whitelist": {}
 }

--- a/src/api/gasPrice.js
+++ b/src/api/gasPrice.js
@@ -1,11 +1,48 @@
+import { restFetch } from 'utils/helpers'
 import { getROGnosisConnection } from 'api'
+import { getGasPriceConfig } from 'utils/features'
+import Decimal from 'decimal.js'
+
+
+const gasPriceConfig = getGasPriceConfig()
+
+export const getGasPriceFromEthereum = async () => {
+  const gnosis = await getROGnosisConnection()
+  const gasPrice = await new Promise((resolve, reject) =>
+    gnosis.web3.eth.getGasPrice((e, r) => (e ? reject(e) : resolve(r))))
+  return gasPrice
+}
+
+const ethGasStationFetch = async () => {
+  const { external: { url } } = gasPriceConfig
+  const response = await restFetch(url)
+
+  if (response && response.safeLow) {
+    return Decimal(response.safeLow).mul(1e8).toString()
+  }
+
+  return response
+}
+
+const ETH_GAS_STATION = 'ETH_GAS_STATION'
+const externalGasPriceFetchers = {
+  [ETH_GAS_STATION]: ethGasStationFetch,
+}
+
+export const getGasPriceFromExternal = async () => {
+  const { external: { type } } = gasPriceConfig
+
+  if (typeof externalGasPriceFetchers[type] === 'function') {
+    return externalGasPriceFetchers[type]()
+  }
+
+  console.warn(`invalid external gasPrice fetcher: ${type}`)
+}
 
 /**
  * Returns the current gas price
  */
 export const getGasPrice = async () => {
-  const gnosis = await getROGnosisConnection()
-  const gasPrice = await new Promise((resolve, reject) =>
-    gnosis.web3.eth.getGasPrice((e, r) => (e ? reject(e) : resolve(r))))
-  return gasPrice
+  const useExternal = typeof gasPriceConfig.external === 'object'
+  return useExternal ? getGasPriceFromExternal() : getGasPriceFromEthereum()
 }

--- a/src/utils/features.js
+++ b/src/utils/features.js
@@ -6,6 +6,8 @@ export const getInterfaceConfiguration = () => configInterface
 
 export const getLogoConfig = () => configInterface.logo
 
+export const getGasPriceConfig = () => config.gasPrice || {}
+
 export const isFeatureEnabled = feature => configInterface[feature] && configInterface[feature].enabled
 
 export const getFeatureConfig = feature => configInterface[feature] && configInterface[feature]


### PR DESCRIPTION
### Description
* Added the ability to configure which source should be used for the current `gasPrice`. Previously used only the web3 `gasPrice` approximation which depended on the last block.
* Improved auto updating of the marketDetail page, previously did all requests every 15s. Changed to wait until all requests are finished or timed out, avoids duplicate requests and maybe makes ethgasstation work a little better.

### Which Tickets does my PR fix? (Put in title too)
* Fixes feature/PM-445

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* Auto Reloading could cause problems if the timeout of requests is not set, but the browser should set this to a reasonable time automatically.

### Which Steps did I take to verify my PR?

*Autoupdating Marketdetails*
* Watched as both working and failing requests happend through the automatic refresh which were handled as usual and did not stop further updates.
* Left the MarketDetail site without any further requests about the market that was previously opened. (componentWillUnmount logic)

*Gas Station Config*
* Without `gasPrice` entry or without `gasPrice.external` it defaults back to getting the `gasPrice` from web3.

### Background Information
* web3's GasPrice is unreliable because it simply uses the `gasPrice` of the last block.

### Configuration Entries
`/config`
```
{
  ...
  "gasPrice": {
    "external": {
       "url": "https://ethgasstation.info/json/ethgasAPI.json",
       "type": "ETH_GAS_STATION"
     },
  },
  ...
}
```