### PR TITLE
PM-620: Disable Interaction when ToS are not accepted

### DIFF
--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -128,7 +128,7 @@ class Header extends Component {
       }
     }
 
-    const shouldShowWallet = (!requireTOSAccept || acceptedTOS) && walletConnected && currentProvider
+    const canInteract = (!requireTOSAccept || acceptedTOS) && walletConnected && currentProvider
 
     return (
       <div className={cx('headerContainer')}>
@@ -140,7 +140,7 @@ class Header extends Component {
           </div>
           <div className={cx('group', 'left', 'version')}>{version}</div>
           <div className={cx('group', 'left', 'navLinks')}>
-            {walletConnected && (
+            {canInteract && (
               <NavLink to="/dashboard" activeClassName={cx('active')} className={cx('navLink')}>
                 Dashboard
               </NavLink>
@@ -148,7 +148,7 @@ class Header extends Component {
             <NavLink to="/markets/list" activeClassName={cx('active')} className={cx('navLink')}>
               Markets
             </NavLink>
-            {walletConnected && (
+            {canInteract && (
               <NavLink to="/transactions" activeClassName={cx('active')} className={cx('navLink')}>
                 Transactions
               </NavLink>
@@ -162,7 +162,7 @@ class Header extends Component {
           </div>
 
           <div className={cx('group', 'right')}>
-            {shouldShowWallet ? (
+            {canInteract ? (
               <div className={cx('account')}>
                 {currentNetwork && currentNetwork !== 'MAIN' && (
                   <span className={cx('network', 'text')}>Network: {upperFirst(currentNetwork.toLowerCase())}</span>

--- a/src/components/ModalContent/AcceptTOS/index.js
+++ b/src/components/ModalContent/AcceptTOS/index.js
@@ -1,21 +1,21 @@
 import React from 'react'
-import { lifecycle } from 'recompose'
 import cn from 'classnames/bind'
 import { Field, reduxForm, propTypes } from 'redux-form'
 import PropTypes from 'prop-types'
+import { getFeatureConfig } from 'utils/features'
 import Checkbox from 'components/Form/Checkbox'
 import style from './AcceptTOS.mod.scss'
-import { getFeatureConfig } from 'utils/features'
 
 const { name = 'the application' } = getFeatureConfig('tournament')
 
 const cx = cn.bind(style)
 
 const AcceptTOS = ({
-  closeModal, tosAgreed, ppAgreed, rdAgreed, initProviders,
+  closeModal, tosAgreed, ppAgreed, rdAgreed, initProviders, setTermsAndConditionsStatus,
 }) => {
   const disabled = !ppAgreed || !tosAgreed || !rdAgreed
   const login = () => {
+    setTermsAndConditionsStatus(['TermsOfService.html', 'PrivacyPolicy.html', 'RiskDisclaimerPolicy.html'])
     initProviders()
     closeModal()
   }
@@ -71,6 +71,7 @@ const AcceptTOS = ({
 AcceptTOS.propTypes = {
   ...propTypes,
   closeModal: PropTypes.func.isRequired,
+  setTermsAndConditionsStatus: PropTypes.func.isRequired,
   tosAgreed: PropTypes.bool,
   ppAgreed: PropTypes.bool,
   rdAgreed: PropTypes.bool,
@@ -87,10 +88,4 @@ AcceptTOS.defaultProps = {
   rdAgreed: false,
 }
 
-const withResetOnMount = lifecycle({
-  componentDidMount() {
-    this.props.reset()
-  },
-})(AcceptTOS)
-
-export default reduxForm(form)(withResetOnMount)
+export default reduxForm(form)(AcceptTOS)

--- a/src/containers/HeaderContainer/store/selectors.js
+++ b/src/containers/HeaderContainer/store/selectors.js
@@ -1,5 +1,4 @@
 import Decimal from 'decimal.js'
-import { formValueSelector } from 'redux-form'
 
 import {
   getCurrentAccount,
@@ -7,6 +6,7 @@ import {
   getCurrentBalance,
   getActiveProvider,
   checkWalletConnection,
+  hasAcceptedTermsAndConditions,
   isConnectedToCorrectNetwork,
   getTargetNetworkId,
   getRegisteredMainnetAddress,
@@ -27,16 +27,6 @@ import { meSelector } from 'routes/Scoreboard/store/selectors'
 const collateralToken = getCollateralToken()
 const gameGuideConfig = getFeatureConfig('gameGuide')
 const logoConfig = getLogoConfig('logo')
-
-const getTOSStatus = (state) => {
-  const getFormValue = formValueSelector('tosAgreement')
-
-  return (
-    !!getFormValue(state, 'agreedWithTOS') &&
-    !!getFormValue(state, 'agreedWithPP') &&
-    !!getFormValue(state, 'agreedWithRDP')
-  )
-}
 
 /**
  * Returns either the balance of the counfigured token of the current balance of ether
@@ -74,6 +64,6 @@ export default state => ({
   gameGuideURL: gameGuideConfig.url,
   tokenAddress: collateralToken && collateralToken.address,
   tokenBalance: getCurrentTokenBalance(state),
-  acceptedTOS: getTOSStatus(state),
+  acceptedTOS: hasAcceptedTermsAndConditions(state),
 })
 

--- a/src/containers/InteractionButton/index.js
+++ b/src/containers/InteractionButton/index.js
@@ -12,6 +12,7 @@ import {
   isConnectedToCorrectNetwork,
   isOnWhitelist,
   checkWalletConnection,
+  hasAcceptedTermsAndConditions,
   getTargetNetworkId,
 } from 'integrations/store/selectors'
 import { ETHEREUM_NETWORK_IDS } from 'integrations/constants'
@@ -48,10 +49,14 @@ class InteractionButton extends Component {
       disabled,
       targetNetworkId,
       loading,
+      termsNotRequiredOrAccepted,
     } = this.props
     if (whitelistRequired && !whitelisted) {
       return null
     }
+
+    // "you need to accept our ToS"
+    const termsAndConditionsError = !termsNotRequiredOrAccepted
 
     // "you need a wallet"
     const walletError = !hasWallet || !gnosisInitialized
@@ -104,12 +109,16 @@ class InteractionButton extends Component {
       )
     }
 
+    if (termsAndConditionsError) {
+      return <Tooltip overlay="You need to accept our terms and conditions before you can with this application.">{btn}</Tooltip>
+    }
+
     if (walletError) {
-      return <Tooltip overlay="You need a wallet connected in order to create a market">{btn}</Tooltip>
+      return <Tooltip overlay="You need a wallet connected before you can interact with this application.">{btn}</Tooltip>
     }
 
     if (networkError) {
-      const wrongNetworkText = `You are connected to the wrong chain. You can only interact using ${upperFirst(ETHEREUM_NETWORK_IDS[targetNetworkId].toLowerCase())} network.`
+      const wrongNetworkText = `You are connected to the wrong ethereum network. You can only interact using ${upperFirst(ETHEREUM_NETWORK_IDS[targetNetworkId].toLowerCase())} network.`
       return <Tooltip overlay={wrongNetworkText}>{btn}</Tooltip>
     }
 
@@ -130,6 +139,7 @@ InteractionButton.propTypes = {
   disabled: PropTypes.bool,
   loading: PropTypes.bool,
   targetNetworkId: PropTypes.number,
+  termsNotRequiredOrAccepted: PropTypes.bool,
 }
 
 InteractionButton.defaultProps = {
@@ -144,6 +154,7 @@ InteractionButton.defaultProps = {
   type: 'button',
   disabled: false,
   loading: false,
+  termsNotRequiredOrAccepted: false,
   targetNetworkId: 0,
 }
 
@@ -153,4 +164,5 @@ export default connect(state => ({
   correctNetwork: isConnectedToCorrectNetwork(state),
   targetNetworkId: getTargetNetworkId(state),
   whitelisted: isOnWhitelist(state),
+  termsNotRequiredOrAccepted: hasAcceptedTermsAndConditions(state),
 }))(InteractionButton)

--- a/src/containers/Modals/ModalAcceptTOS/index.js
+++ b/src/containers/Modals/ModalAcceptTOS/index.js
@@ -1,7 +1,7 @@
 import AcceptTOS from 'components/ModalContent/AcceptTOS'
 import { connect } from 'react-redux'
 import { formValueSelector } from 'redux-form'
-import { initProviders } from 'integrations/store/actions'
+import { initProviders, setTermsAndConditionsStatus } from 'integrations/store/actions'
 
 const mapStateToProps = (state) => {
   const getFormValue = formValueSelector('tosAgreement')
@@ -13,8 +13,9 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = dispatch => ({
-  initProviders: () => dispatch(initProviders()),
-})
+const mapDispatchToProps = {
+  initProviders,
+  setTermsAndConditionsStatus,
+}
 
 export default connect(mapStateToProps, mapDispatchToProps)(AcceptTOS)

--- a/src/integrations/store/actions/index.js
+++ b/src/integrations/store/actions/index.js
@@ -10,6 +10,7 @@ export const updateProvider = createAction('UPDATE_PROVIDER')
 export const logout = createAction('PROVIDER_LOGOUT')
 export const setActiveProvider = createAction('SET_ACTIVE_PROVIDER')
 export const initProviders = createAction('INIT_PROVIDERS')
+export const setTermsAndConditionsStatus = createAction('SET_TERMS_AND_CONDITION_STATUS')
 
 const GNOSIS_REINIT_KEYS = ['network', 'account', 'available']
 

--- a/src/integrations/store/reducers/index.js
+++ b/src/integrations/store/reducers/index.js
@@ -1,6 +1,6 @@
-import { Map } from 'immutable'
+import { Map, List } from 'immutable'
 import { handleActions } from 'redux-actions'
-import { registerProvider, updateProvider, setActiveProvider } from 'integrations/store/actions'
+import { registerProvider, updateProvider, setActiveProvider, setTermsAndConditionsStatus } from 'integrations/store/actions'
 import { ProviderRecord } from 'integrations/store/models'
 
 export default handleActions(
@@ -17,9 +17,11 @@ export default handleActions(
       const newProviderState = currentProviderState.merge(updatedProvider)
       return state.setIn(['providers', name], newProviderState)
     },
+    [setTermsAndConditionsStatus]: (state, { payload: docs }) => state.set('termsAndConditionsAccepted', List(docs)),
   },
   Map({
     providers: Map(),
     activeProvider: undefined,
+    termsAndConditionsAccepted: List(),
   }),
 )

--- a/src/integrations/store/selectors/index.js
+++ b/src/integrations/store/selectors/index.js
@@ -1,7 +1,11 @@
 import { WALLET_PROVIDER } from 'integrations/constants'
-import { getConfiguration } from 'utils/features'
+import { getConfiguration, getFeatureConfig } from 'utils/features'
+import { formValueSelector } from 'redux-form'
 
 const config = getConfiguration()
+
+const providerConfig = getFeatureConfig('providers')
+const requireTOSAccept = !!providerConfig.requireTOSAccept
 
 /**
  * Finds a default provider from all currently available providers. Determined by provider integrations `priority`
@@ -39,10 +43,20 @@ export const getCurrentAccount = (state) => {
   return undefined
 }
 
+export const hasAcceptedTermsAndConditions = (state) => {
+  if (!requireTOSAccept) {
+    return true
+  }
+
+  // TODO: In the future we can check against which were accepted
+  return !state.integrations.get('termsAndConditionsAccepted').isEmpty()
+}
+
 export const checkWalletConnection = (state) => {
   const provider = getActiveProvider(state)
+  const termsNotRequiredOrAccepted = hasAcceptedTermsAndConditions(state)
 
-  if (provider && provider.account) {
+  if (termsNotRequiredOrAccepted && provider && provider.account) {
     return true
   }
 


### PR DESCRIPTION
### Description
* Added another check to the function that determines if the user is able to interact with the interface.

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-620

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* /

### Which Steps did I take to verify my PR?

*Accepted TOS*
* Was able to interact with platform. Refreshed page, needed to accept ToS again.

*Disable TOS*
* Was able to interact without having to accept ToS.

### Background Information
* ToS Document names are now stored in the reducer, this way we can later check exactly which documents were accepted and which revisions. Not implemented for now.

### Configuration Entries
* /