### PR TITLE
Bug PM-617: Legal Documents weren't included in build

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 const path = require('path')
 const webpack = require('webpack')
@@ -158,6 +159,9 @@ module.exports = (env = {}) => {
         'window.GNOSIS_INTERFACE': JSON.stringify(interfaceConfig),
       }),
       new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en/),
+      new CopyWebpackPlugin([
+        { from: path.join(__dirname, 'src/assets'), to: path.join(__dirname, 'dist/assets') },
+      ]),
     ],
   }
 }

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -2,6 +2,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin')
 const UglifyJsWebpackPlugin = require('uglifyjs-webpack-plugin')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 const path = require('path')
 const webpack = require('webpack')
@@ -142,6 +143,9 @@ module.exports = (env = {}) => {
         },
       }),
       new webpack.ContextReplacementPlugin(/moment[/\\]locale$/, /en/),
+      new CopyWebpackPlugin([
+        { from: path.join(__dirname, 'src/assets'), to: path.join(__dirname, 'dist/assets') },
+      ]),
     ],
   }
 }


### PR DESCRIPTION
### Description
* Added the `src/assets` folder to `dist/assets` on build, to allow linking from CSS to assets and to be able to link to documents in that folder.

### Which Tickets does my PR fix? (Put in title too)
* Fixes bug/PM-617

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* Could still not be viewable due to nginx configuration

### Which Steps did I take to verify my PR?

*Build Webpack*
* Folder copied correctly.

### Background Information
* /

### Configuration Entries