### PR TITLE
Task: Webpack/SCSS Import Cleanup

### DIFF
--- a/src/components/Form/Checkbox.mod.scss
+++ b/src/components/Form/Checkbox.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .formCheckbox {
   display: inline-block;

--- a/src/components/Form/InputError.mod.scss
+++ b/src/components/Form/InputError.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .inputError {
   position: absolute;

--- a/src/components/Form/OutcomeSelection/OutcomeSelection.mod.scss
+++ b/src/components/Form/OutcomeSelection/OutcomeSelection.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .formOutcomeSelection {
   width: 100%;

--- a/src/components/Form/RadioButton.mod.scss
+++ b/src/components/Form/RadioButton.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .formRadioButton {
   padding: $paddings-inputs;

--- a/src/components/Form/RadioButtonGroup.mod.scss
+++ b/src/components/Form/RadioButtonGroup.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .formRadioButtonGroup {
   &.error {

--- a/src/components/Form/Select.mod.scss
+++ b/src/components/Form/Select.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .formSelect {
   .Select-control {

--- a/src/components/Form/Slider.mod.scss
+++ b/src/components/Form/Slider.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 @mixin slider($color) {
   border: none;

--- a/src/components/Form/TextInput.mod.scss
+++ b/src/components/Form/TextInput.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .wrapper {
   display: flex;

--- a/src/components/Form/TextInputAdornment.mod.scss
+++ b/src/components/Form/TextInputAdornment.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .adornment {
   display: block;

--- a/src/components/Header/Header.mod.scss
+++ b/src/components/Header/Header.mod.scss
@@ -1,4 +1,4 @@
-@import '../../scss/vars.scss';
+@import '~style/vars.scss';
 
 $navbarHeight: 40px;
 .headerContainer {

--- a/src/components/ModalContent/AcceptTOS/AcceptTOS.mod.scss
+++ b/src/components/ModalContent/AcceptTOS/AcceptTOS.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .acceptTOS {
   width: 100%;

--- a/src/components/ModalContent/ClaimReward/ClaimReward.mod.scss
+++ b/src/components/ModalContent/ClaimReward/ClaimReward.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .claimRewards {
   width: 100%;

--- a/src/components/ModalContent/InstallMetamask/InstallMetamask.mod.scss
+++ b/src/components/ModalContent/InstallMetamask/InstallMetamask.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .installMetamask {
   width: 100%;

--- a/src/components/ModalContent/RegisterWallet/RegisterWallet.mod.scss
+++ b/src/components/ModalContent/RegisterWallet/RegisterWallet.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .registerWallet {
   width: 100%;

--- a/src/components/ModalContent/RegisterWalletUport/RegisterWalletUport.mod.scss
+++ b/src/components/ModalContent/RegisterWalletUport/RegisterWalletUport.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .setMainnetAddress {
   display: flex;

--- a/src/components/ModalContent/SwitchNetwork/SwitchNetwork.mod.scss
+++ b/src/components/ModalContent/SwitchNetwork/SwitchNetwork.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .switchNetwork {
   width: 100%;

--- a/src/components/ModalContent/TransactionsExplanation/TransactionExplanation.scss
+++ b/src/components/ModalContent/TransactionsExplanation/TransactionExplanation.scss
@@ -1,4 +1,4 @@
-@import "../../../scss/vars.scss";
+@import "~style/vars.scss";
 
 .transactionsExplanation {
   display: flex;

--- a/src/components/ModalContent/UnlockMetamask/UnlockMetamask.mod.scss
+++ b/src/components/ModalContent/UnlockMetamask/UnlockMetamask.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .unlockMetamask {
   width: 100%;

--- a/src/components/Notifications/Notifications.mod.scss
+++ b/src/components/Notifications/Notifications.mod.scss
@@ -1,4 +1,4 @@
-@import '../../scss/vars.scss';
+@import '~style/vars.scss';
 @keyframes slideInFromRight {
   0% {
     transform: translateX(400px);

--- a/src/components/Outcome/OutcomeCategorical/outcomeCategorical.mod.scss
+++ b/src/components/Outcome/OutcomeCategorical/outcomeCategorical.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 $outcome-bar-height: 15px;
 $outcome-bar-height-leading: 30px;

--- a/src/components/Outcome/OutcomeScalar/outcomeScalar.mod.scss
+++ b/src/components/Outcome/OutcomeScalar/outcomeScalar.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 $expandable-arrow-size: 7px;
 

--- a/src/components/Spinner/Labeled.mod.scss
+++ b/src/components/Spinner/Labeled.mod.scss
@@ -1,4 +1,4 @@
-@import '../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .labeledSpinner {
   position: relative;

--- a/src/components/TransactionFloater/Notifications/Notifications.mod.scss
+++ b/src/components/TransactionFloater/Notifications/Notifications.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 @keyframes slideInFromRight {
   0% {

--- a/src/components/TransactionFloater/transactionFloater.mod.scss
+++ b/src/components/TransactionFloater/transactionFloater.mod.scss
@@ -1,4 +1,4 @@
-@import '../../scss/vars.scss';
+@import '~style/vars.scss';
 
 $expandable-arrow-size: 4px;
 $expandable-arrow-margin: 12px;

--- a/src/containers/App/app.mod.scss
+++ b/src/containers/App/app.mod.scss
@@ -1,4 +1,4 @@
-@import "../../scss/vars.scss";
+@import "~style/vars.scss";
 
 $footer-bottom: 44px;
 

--- a/src/containers/LegalCompliance/components/Form.mod.scss
+++ b/src/containers/LegalCompliance/components/Form.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .checks {
   text-align: left;

--- a/src/routes/Dashboard/components/Dashboard/Markets/Category.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/Markets/Category.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../scss/vars";
+@import "~style/vars.scss";
 
 .marketList {
   min-height: 200px;

--- a/src/routes/Dashboard/components/Dashboard/Markets/Market/Market.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/Markets/Market/Market.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../scss/vars";
+@import "~style/vars.scss";
 
 .market {
   display: flex;

--- a/src/routes/Dashboard/components/Dashboard/Markets/Markets.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/Markets/Markets.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../scss/vars";
+@import "~style/vars.scss";
 
 .dashboardOverview {
   background-color: $bg-color-muted;

--- a/src/routes/Dashboard/components/Dashboard/Title/DashboardTitle.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/Title/DashboardTitle.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .dashboardTitle {
   .title {

--- a/src/routes/Dashboard/components/Dashboard/UserSection/Category.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/UserSection/Category.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .category {
   min-height: 200px;

--- a/src/routes/Dashboard/components/Dashboard/UserSection/Holdings/style.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/UserSection/Holdings/style.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .holding {
   margin-bottom: 30px;

--- a/src/routes/Dashboard/components/Dashboard/UserSection/UserSection.mod.scss
+++ b/src/routes/Dashboard/components/Dashboard/UserSection/UserSection.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .userSection {
   padding: 40px 0 66px 0;

--- a/src/routes/GameGuide/components/metamaskComponents/SignUp/SignUp.mod.scss
+++ b/src/routes/GameGuide/components/metamaskComponents/SignUp/SignUp.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars';
+@import '~style/vars.scss';
 .link {
   text-decoration: underline;
   color: $link-color;

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/OutcomesSection/OutcomeSectionScalar/ScalarSlider/scalarSlider.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/OutcomesSection/OutcomeSectionScalar/ScalarSlider/scalarSlider.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../../../scss/vars.scss";
+@import "~style/vars.scss";
 
 $slider-stroke-size: 2px;
 $slider-handle-size: 16px;

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/marketBuySharesForm.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketBuySharesForm/marketBuySharesForm.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../scss/vars";
+@import "~style/vars.scss";
 @import "../../../../../components/Form/Slider.mod.scss";
 
 .marketBuySharesForm {

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/ShareRow/ShareRow.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/ShareRow/ShareRow.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .ShareSellButton {
     color: $link-color !important;

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/ShareSellView/ShareSellView.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/ShareSellView/ShareSellView.mod.scss
@@ -1,5 +1,5 @@
 @import '../../../../../../../components/Form/Slider.mod.scss';
-@import '../../../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .sellView {
   td {

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/SharesTable.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMySharesForm/SharesTable/SharesTable.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../../scss/vars";
+@import "~style/vars.scss";
 
 $indexWidth: 36px;
 $groupWidth: 33%;

--- a/src/routes/MarketDetails/components/ExpandableViews/MarketMyTrades/marketMyTrades.mod.scss
+++ b/src/routes/MarketDetails/components/ExpandableViews/MarketMyTrades/marketMyTrades.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars';
+@import '~style/vars.scss';
 
 $indexWidth: 36px;
 $groupWidth: 20%;

--- a/src/routes/MarketDetails/components/MarketDetail/Controls/Controls.mod.scss
+++ b/src/routes/MarketDetails/components/MarketDetail/Controls/Controls.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../../scss/vars";
+@import "~style/vars.scss";
 
 $expandable-arrow-size: 15px;
 $expandable-margin: 40px;

--- a/src/routes/MarketDetails/components/MarketDetail/Details/MarketTimer/MarketTimer.mod.scss
+++ b/src/routes/MarketDetails/components/MarketDetail/Details/MarketTimer/MarketTimer.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .marketTimer {
   margin-top: 12px;

--- a/src/routes/MarketDetails/components/MarketDetail/Details/RedeemWinnings/RedeemWinnings.mod.scss
+++ b/src/routes/MarketDetails/components/MarketDetail/Details/RedeemWinnings/RedeemWinnings.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .redeemWinning {
   display: flex;

--- a/src/routes/MarketDetails/components/MarketDetail/Infos/Infos.mod.scss
+++ b/src/routes/MarketDetails/components/MarketDetail/Infos/Infos.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .marketInfoСontainer {
   text-align: left;

--- a/src/routes/MarketDetails/components/MarketDetail/marketDetail.mod.scss
+++ b/src/routes/MarketDetails/components/MarketDetail/marketDetail.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../scss/vars";
+@import "~style/vars.scss";
 
 $expandable-arrow-size: 15px;
 $expandable-margin: 40px;

--- a/src/routes/MarketDetails/components/MarketGraph/MarketGraph.mod.scss
+++ b/src/routes/MarketDetails/components/MarketGraph/MarketGraph.mod.scss
@@ -1,4 +1,4 @@
-@import "../../../../scss/vars";
+@import "~style/vars.scss";
 
 .marketGraph {
   width: 100%;

--- a/src/routes/MarketList/components/MarketOverview/MarketOverview.mod.scss
+++ b/src/routes/MarketList/components/MarketOverview/MarketOverview.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .marketOverview {
   padding: 40px 0;

--- a/src/routes/MarketList/components/MarketStats/MarketStats.mod.scss
+++ b/src/routes/MarketList/components/MarketStats/MarketStats.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .marketStats {
   margin: 42px 0;

--- a/src/routes/MarketList/components/Markets/Market/Market.mod.scss
+++ b/src/routes/MarketList/components/Markets/Market/Market.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 $market-border-radius: 12px;
 $market-highlight-stripe-width: 5px;

--- a/src/routes/MarketList/components/Markets/Markets.mod.scss
+++ b/src/routes/MarketList/components/Markets/Markets.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .markets {
   .title {

--- a/src/routes/MarketList/components/MarketsTitle/MarketsTitle.mod.scss
+++ b/src/routes/MarketList/components/MarketsTitle/MarketsTitle.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../scss/vars.scss';
+@import '~style/vars.scss';
 
 .marketListTitle {
   h1 {

--- a/src/routes/Transactions/components/Transactions/Transaction/DetailLabel/DetailLabel.mod.scss
+++ b/src/routes/Transactions/components/Transactions/Transaction/DetailLabel/DetailLabel.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../scss/vars';
+@import '~style/vars.scss';
 
 .detailLabel {
   color: $font-color-light;

--- a/src/routes/Transactions/components/Transactions/Transactions.mod.scss
+++ b/src/routes/Transactions/components/Transactions/Transactions.mod.scss
@@ -1,4 +1,4 @@
-@import '../../../../scss/vars';
+@import '~style/vars.scss';
 
 .transactionsPage {
   padding-top: 50px;

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -33,6 +33,9 @@ module.exports = (env = {}) => {
     },
     resolve: {
       symlinks: false,
+      alias: {
+        '~style': `${__dirname}/src/scss`,
+      },
       modules: [
         `${__dirname}/src`,
         `${__dirname}/package.json`,

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -33,6 +33,9 @@ module.exports = (env = {}) => {
     },
     resolve: {
       symlinks: false,
+      alias: {
+        '~style': `${__dirname}/src/scss`,
+      },
       modules: [
         `${__dirname}/src`,
         `${__dirname}/package.json`,


### PR DESCRIPTION
### Description
* Replaces all `../../../scss/vars` and similar imports in `.scss` files with an alias to the `scss` folder named `~style`

### Which Tickets does my PR fix? (Put in title too)
* /

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* Can't think of any, all scss still compiles and works. It would error if the files imported were not found.

### Which Steps did I take to verify my PR?

*Check build*
* Still builds

*UI Look/Design*
* Still the same

### Background Information
* the `.../../../../` is really annoying so I think this solution is way better and a first step at cleaning up some of the styles as well.
* Most important (and only reviewable change) is this: https://github.com/gnosis/pm-trading-ui/pull/441/files#diff-361932ce6b04b8880716e7995633922a

### Configuration Entries
/