### PR TITLE
Bugfix: Claim Reward System with Hashed Config

### DIFF
--- a/src/components/ModalContent/ClaimReward/index.js
+++ b/src/components/ModalContent/ClaimReward/index.js
@@ -33,10 +33,10 @@ class ClaimReward extends React.Component {
   }
 
   async handleClaim() {
-    const { closeModal, claimUserRewards } = this.props
+    const { closeModal, claimUserRewards, rewardValue } = this.props
     await this.setState({ claimState: 'loading' })
     try {
-      await claimUserRewards()
+      await claimUserRewards(rewardValue)
       await this.setState({ claimState: 'success' })
     } catch (e) {
       await this.setState({ claimState: 'error' })
@@ -55,6 +55,7 @@ class ClaimReward extends React.Component {
       claimRewardGasCost,
       currentBalance,
       rewardValue,
+      hasClaimedReward,
     } = this.props
 
     const { claimState } = this.state
@@ -83,7 +84,16 @@ class ClaimReward extends React.Component {
     const canClaim = sufficentFunds && !isWrongNetwork
 
     let claimButton
-    if (claimState === 'loading') {
+    if (hasClaimedReward) {
+      claimButton = (
+        <button
+          className={cx('btn', 'btn-primary', 'claim', 'disabled')}
+          disabled
+        >
+          ALREADY CLAIMED
+        </button>
+      )
+    } else if (claimState === 'loading') {
       claimButton = (
         <button
           className={cx('btn', 'btn-primary', 'claim', 'disabled')}

--- a/src/containers/Modals/ModalClaimReward/index.js
+++ b/src/containers/Modals/ModalClaimReward/index.js
@@ -12,7 +12,7 @@ import { getGasPrice } from 'routes/MarketDetails/store/selectors'
 import { claimUserRewards } from 'routes/Scoreboard/store/actions'
 import { getFeatureConfig } from 'utils/features'
 import { requestClaimRewardGasCost } from './action'
-import { getClaimRewardGasCost, getRewardValue } from './selectors'
+import { getClaimRewardGasCost, getRewardValue, hasClaimedReward } from './selectors'
 
 const { claimReward } = getFeatureConfig('rewardClaiming')
 
@@ -24,13 +24,14 @@ const mapStateToProps = state => ({
   currentNetworkId: getCurrentNetworkId(state),
   claimRewardGasCost: getClaimRewardGasCost(state),
   rewardValue: getRewardValue(state),
+  hasClaimedReward: hasClaimedReward(state),
 })
 
 const mapDispatchToProps = {
   requestGasPrice,
   requestClaimRewardGasCost,
   closeModal,
-  claimUserRewards: () => claimUserRewards(claimReward.contractAddress),
+  claimUserRewards: rewardAmount => claimUserRewards(claimReward.contractAddress, rewardAmount),
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(ClaimReward)

--- a/src/containers/Modals/ModalClaimReward/selectors.js
+++ b/src/containers/Modals/ModalClaimReward/selectors.js
@@ -2,10 +2,12 @@ import { GAS_COST } from 'utils/constants'
 import { rankSelector } from 'routes/Scoreboard/store/selectors'
 import { createSelector } from 'reselect'
 import { getFeatureConfig } from 'utils/features'
+import { getCurrentAccount } from 'integrations/store/selectors'
+import sha1 from 'sha1'
 
-const { levels } = getFeatureConfig('rewards')
+const { levels, claimUntil } = getFeatureConfig('rewards')
 
-const getClaimRewardGasCost = (state) => {
+export const getClaimRewardGasCost = (state) => {
   const gasCost = state.blockchain.getIn(['gasCosts', GAS_COST.CLAIM_REWARD], 0)
 
   return gasCost
@@ -16,8 +18,8 @@ export const getRewardValue = createSelector(rankSelector, (rank) => {
 
   levels.forEach((rewardLevel) => {
     if (
-      (rank >= rewardLevel.minRank && rank <= rewardLevel.maxRank) || // between min/max
-      (rank >= rewardLevel.minRank && rewardLevel.maxRank == null) // above min
+      (rank >= rewardLevel.minRank && rank <= rewardLevel.maxRank) // between min/max
+      || (rank >= rewardLevel.minRank && rewardLevel.maxRank == null) // above min
     ) {
       rewardValue = rewardLevel.value
     }
@@ -26,4 +28,10 @@ export const getRewardValue = createSelector(rankSelector, (rank) => {
   return rewardValue
 })
 
-export { getClaimRewardGasCost }
+export const hasClaimedReward = (state) => {
+  const rewardValue = getRewardValue(state)
+  const account = getCurrentAccount(state)
+  const currentRewardClaimHash = sha1(`${claimUntil}${rewardValue}`)
+
+  return state.integrations.getIn(['accountSettings', account, 'rewardClaimHash']) === currentRewardClaimHash
+}

--- a/src/routes/Scoreboard/components/ClaimReward/index.js
+++ b/src/routes/Scoreboard/components/ClaimReward/index.js
@@ -23,18 +23,15 @@ const cx = cn.bind(style)
 const claimStartDate = moment.utc(claimReward.claimStart)
 const claimEndDate = moment.utc(claimReward.claimUntil)
 
-const ClaimReward = ({ openClaimRewardModal, rewardValue, rewardClaimHash }) => {
+const ClaimReward = ({ openClaimRewardModal, rewardValue, alreadyClaimed }) => {
   const isInTimeframe = moment.utc().isBetween(claimStartDate, claimEndDate)
   const hasRewards = Decimal(rewardValue || 0).gt(0)
   const claimRewardEnabled = claimReward.enabled
 
-  const currentRewardClaimHash = sha1(claimReward.claimUntil + rewardValue)
-  const hasClaimedRewards = rewardClaimHash === currentRewardClaimHash
+  const showRewardValue = claimRewardEnabled && isInTimeframe && !alreadyClaimed
+  const showAlreadyClaimed = isInTimeframe && alreadyClaimed
 
-  const showRewardValue = claimRewardEnabled && isInTimeframe && !hasClaimedRewards
-  const showAlreadyClaimed = isInTimeframe && hasClaimedRewards
-
-  const claimingDisabled = !claimRewardEnabled || !isInTimeframe || hasClaimedRewards || !hasRewards
+  const claimingDisabled = !claimRewardEnabled || !isInTimeframe || alreadyClaimed || !hasRewards
 
   let rewardValueDisplay = 'N/A'
   if (showRewardValue) {

--- a/src/routes/Scoreboard/components/Layout.js
+++ b/src/routes/Scoreboard/components/Layout.js
@@ -28,7 +28,7 @@ const NoRows = () => <Paragraph className={cx('norows')}>No rows found</Paragrap
 class Layout extends React.PureComponent {
   render() {
     const {
-      data, myAccount, mainnetAddress, openSetMainnetAddressModal, openClaimRewardModal, rank,
+      data, myAccount, mainnetAddress, openSetMainnetAddressModal, openClaimRewardModal, rank, hasClaimedReward,
     } = this.props
     const hasRows = data && data.size > 0
     let rewardValue = 0
@@ -56,7 +56,11 @@ class Layout extends React.PureComponent {
                   openSetMainnetAddressModal={openSetMainnetAddressModal}
                 />
                 {showRewardClaim && (
-                  <ClaimReward openClaimRewardModal={openClaimRewardModal} rewardValue={rewardValue} />
+                  <ClaimReward
+                    openClaimRewardModal={openClaimRewardModal}
+                    rewardValue={rewardValue}
+                    alreadyClaimed={hasClaimedReward}
+                  />
                 )}
               </Block>
               <Hairline />

--- a/src/routes/Scoreboard/containers/ScoreBoard.js
+++ b/src/routes/Scoreboard/containers/ScoreBoard.js
@@ -17,7 +17,7 @@ class ScoreBoard extends React.Component {
 
   render() {
     const {
-      data, myAccount, mainnetAddress, openSetMainnetAddressModal, openClaimRewardModal, rank,
+      data, myAccount, mainnetAddress, openSetMainnetAddressModal, openClaimRewardModal, rank, hasClaimedReward,
     } = this.props
 
     return (
@@ -28,6 +28,7 @@ class ScoreBoard extends React.Component {
         openSetMainnetAddressModal={openSetMainnetAddressModal}
         openClaimRewardModal={openClaimRewardModal}
         rank={rank}
+        hasClaimedReward={hasClaimedReward}
       />
     )
   }

--- a/src/routes/Scoreboard/containers/selector.js
+++ b/src/routes/Scoreboard/containers/selector.js
@@ -1,6 +1,7 @@
 import { createSelector, createStructuredSelector } from 'reselect'
 import { getCurrentAccount, getRegisteredMainnetAddress } from 'integrations/store/selectors'
 import { rankSelector } from 'routes/Scoreboard/store/selectors'
+import { hasClaimedReward } from 'containers/Modals/ModalClaimReward/selectors'
 import { firstTournamentUsersSelectorAsList, meSelector } from '../store/selectors'
 
 const usersSelector = createSelector(firstTournamentUsersSelectorAsList, meSelector, (firstUsers, me) => {
@@ -23,4 +24,5 @@ export default createStructuredSelector({
   mainnetAddress: getRegisteredMainnetAddress,
   myAccount: getCurrentAccount,
   rank: rankSelector,
+  hasClaimedReward,
 })

--- a/src/routes/Scoreboard/store/actions/rewards.js
+++ b/src/routes/Scoreboard/store/actions/rewards.js
@@ -1,12 +1,17 @@
 import { claimRewards } from 'api'
-import { createAction } from 'redux-actions'
 
-export const rewardsClaimed = createAction('REWARDS_CLAIMED')
+import { setAccountRewardClaimState } from 'store/actions/account'
+import { getCurrentAccount } from 'integrations/store/selectors'
+import { getFeatureConfig } from 'utils/features'
 
-export const claimUserRewards = contractAddress => async (dispatch) => {
+const { claimUntil } = getFeatureConfig('rewards')
+
+export const claimUserRewards = (contractAddress, rewardClaimAmount) => async (dispatch, getState) => {
+  const state = getState()
+  const account = getCurrentAccount(state)
   try {
-    await claimRewards(contractAddress)
-    dispatch(rewardsClaimed())
+    await claimRewards(contractAddress) // These arguments get hashed, this way we can determine if claiming is available again
+    dispatch(setAccountRewardClaimState(account, claimUntil, rewardClaimAmount))
   } catch (e) {
     console.error(e)
   }

--- a/src/store/actions/account.js
+++ b/src/store/actions/account.js
@@ -10,7 +10,7 @@ const registrationConfig = getFeatureConfig('registration')
 export const setMainnetAddress = (account, mainnetAddress) => saveWalletSetting({ account, key: 'mainnetAddress', value: mainnetAddress })
 export const setAccountAcceptedDocuments = (account, documentNames) => saveWalletSetting({ account, key: 'acceptedDocuments', value: documentNames })
 export const setAccountRewardClaimState = (account, rewardClaimEnd, rewardClaimValue) => (
-  saveWalletSetting({ account, key: 'rewardClaimHash', value: sha1(rewardClaimEnd + rewardClaimValue) })
+  saveWalletSetting({ account, key: 'rewardClaimHash', value: sha1(`${rewardClaimEnd}${rewardClaimValue}`) })
 )
 
 export const requestMainnetAddress = () => async (dispatch, getState) => {


### PR DESCRIPTION
### Description
* Implements the ability to remember the previous reward-claim (aka which configuration and value it was, e.g. claiming was available until + the value that was rewarded) to determine if we can reward claim again. 
### Which Tickets does my PR fix? (Put in title too)
* /

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* /

### Which Steps did I take to verify my PR?
*Smoke Tested*
No errors or problems. Claiming worked and showed "already claimed" after I claimed the rewards once.

### Background Information
* Was removed during Backmerge

### Configuration Entries
/