### PR TITLE
#510 Enable WETH + ETH abstraction

### DIFF
--- a/config/fallback.json
+++ b/config/fallback.json
@@ -33,7 +33,8 @@
     "source": "contract",
     "options": {
       "contractName": "etherToken",
-      "symbol": "WETH",
+      "isWrappedEther": true,
+      "symbol": "ETH",
       "icon": "/assets/img/icons/icon_etherTokens.svg"
     }
   },

--- a/src/components/Header/BadgeIcon.js
+++ b/src/components/Header/BadgeIcon.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import Tooltip from 'rc-tooltip'
 import ImmutablePropTypes from 'react-immutable-proptypes'
 import Icon from 'components/Icon'

--- a/src/components/Header/Balance.js
+++ b/src/components/Header/Balance.js
@@ -21,7 +21,7 @@ const Balance = ({
   if (isWrappedEther) {
     const balanceTooltip = (
       <div className={cx('weth-explanation')}>
-        <strong>{Decimal(tokenBalance).sub(etherBalance).toDP(3).toString()} {tokenSymbol}</strong> + <strong>{Decimal(etherBalance).toDP(3).toString()} ETH</strong>
+        <strong>{Decimal(tokenBalance).sub(etherBalance).toDP(3).toString()} {tokenSymbol === 'ETH' ? 'WETH' : tokenSymbol}</strong> + <strong>{Decimal(etherBalance).toDP(3).toString()} ETH</strong>
         <p>
           Your balance is calculated as the sum
           of your ETH and Wrapped-ETH balance.<br />

--- a/src/components/Header/Balance.js
+++ b/src/components/Header/Balance.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import className from 'classnames/bind'
+import Tooltip from 'rc-tooltip'
+import Decimal from 'decimal.js'
+
+import Indefinite from 'components/Spinner/Indefinite'
+import DecimalValue from 'components/DecimalValue'
+
+import css from './Header.scss'
+
+const cx = className.bind(css)
+
+const Balance = ({
+  tokenBalance, tokenSymbol, etherBalance, isWrappedEther,
+}) => {
+  if (!tokenBalance) {
+    return <Indefinite width={24} height={24} />
+  }
+
+  const balance = <DecimalValue value={tokenBalance} className={cx('text')} />
+  if (isWrappedEther) {
+    const balanceTooltip = (
+      <div className={cx('weth-explanation')}>
+        <strong>{Decimal(tokenBalance).sub(etherBalance).toDP(3).toString()} {tokenSymbol}</strong> + <strong>{Decimal(etherBalance).toDP(3).toString()} ETH</strong>
+        <p>Your balance is calculated as the sum of your ETH and Wrapped-ETH balance.<br /> <a href="https://weth.io" target="_blank" rel="noopener noreferrer">What&apos;s wrapped ether?</a></p>
+      </div>
+    )
+
+    return (
+      <>{balance} <Tooltip overlay={balanceTooltip} placement="bottom"><span className={cx('symbol', 'wrapped')}>{tokenSymbol}</span></Tooltip></>
+    )
+  }
+
+  return (
+    <>{balance} <span className={cx('symbol')}>{tokenBalance}</span></>
+  )
+}
+
+Balance.defaultProps = {
+  tokenBalance: undefined,
+  tokenSymbol: 'ETH',
+  etherBalance: '0',
+}
+
+export default Balance

--- a/src/components/Header/Balance.js
+++ b/src/components/Header/Balance.js
@@ -22,7 +22,17 @@ const Balance = ({
     const balanceTooltip = (
       <div className={cx('weth-explanation')}>
         <strong>{Decimal(tokenBalance).sub(etherBalance).toDP(3).toString()} {tokenSymbol}</strong> + <strong>{Decimal(etherBalance).toDP(3).toString()} ETH</strong>
-        <p>Your balance is calculated as the sum of your ETH and Wrapped-ETH balance.<br /> <a href="https://weth.io" target="_blank" rel="noopener noreferrer">What&apos;s wrapped ether?</a></p>
+        <p>
+          Your balance is calculated as the sum
+          of your ETH and Wrapped-ETH balance.<br />
+          <a
+            href="https://weth.io"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            What&apos;s wrapped ether?
+          </a>
+        </p>
       </div>
     )
 

--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -172,3 +172,13 @@ $navbarHeight: 40px;
     }
   }
 }
+
+.weth-explanation {
+  max-width: 250px;
+  text-align: center;
+}
+
+.symbol {
+  text-decoration: underline; 
+  text-decoration-style: dotted;
+}

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -4,7 +4,6 @@ import { NavLink } from 'react-router-dom'
 import autobind from 'autobind-decorator'
 import { upperFirst } from 'lodash'
 import className from 'classnames/bind'
-import DecimalValue from 'components/DecimalValue'
 import { providerPropType } from 'utils/shapes'
 import { isFeatureEnabled, getFeatureConfig } from 'utils/features'
 import { hasMetamask } from 'integrations/metamask/utils'
@@ -126,7 +125,9 @@ class Header extends Component {
       hasVerified,
     } = this.props
 
-    let canInteract = (acceptedTOS || !legalComplianceEnabled) && (hasVerified || !requireVerification) && hasWallet && !!currentProvider
+    let canInteract = (acceptedTOS || !legalComplianceEnabled)
+      && (hasVerified || !requireVerification)
+      && hasWallet && !!currentProvider
 
     if (tournamentEnabled && useMetamask && requireRegistration) {
       canInteract = hasWallet && !!mainnetAddress

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -14,6 +14,7 @@ import Identicon from './Identicon'
 import ProviderIcon from './ProviderIcon'
 import BadgeIcon from './BadgeIcon'
 import MenuAccountDropdown from './MenuAccountDropdown'
+import Balance from './Balance'
 
 import css from './Header.scss'
 
@@ -108,7 +109,9 @@ class Header extends Component {
       hasWallet,
       currentAccount,
       currentNetwork,
+      etherBalance,
       tokenBalance,
+      tokenBalanceIsWrappedEther,
       currentProvider,
       logoPath,
       smallLogoPath,
@@ -190,9 +193,12 @@ class Header extends Component {
                     {upperFirst(currentNetwork.toLowerCase())}
                   </span>
                 )}
-                <DecimalValue value={tokenBalance} className={cx('text')} />
-                &nbsp;
-                {<span>{tokenSymbol || 'ETH'}</span>}
+                <Balance
+                  etherBalance={etherBalance}
+                  tokenBalance={tokenBalance}
+                  tokenSymbol={tokenSymbol}
+                  isWrappedEther={tokenBalanceIsWrappedEther}
+                />
                 {badgesEnabled && <BadgeIcon userTournamentInfo={userTournamentInfo} />}
                 <ProviderIcon provider={currentProvider} />
                 <Identicon account={currentAccount} />
@@ -214,7 +220,9 @@ Header.propTypes = {
   version: PropTypes.string,
   currentNetwork: PropTypes.string,
   hasWallet: PropTypes.bool,
+  etherBalance: PropTypes.string,
   tokenBalance: PropTypes.string,
+  tokenBalanceIsWrappedEther: PropTypes.bool,
   currentProvider: providerPropType,
   currentAccount: PropTypes.string,
   userTournamentInfo: PropTypes.shape({}),
@@ -241,6 +249,7 @@ Header.defaultProps = {
   currentNetwork: '',
   hasWallet: false,
   tokenBalance: '0',
+  etherBalance: '0',
   currentProvider: {},
   currentAccount: '',
   showScoreboard: false,
@@ -251,6 +260,7 @@ Header.defaultProps = {
   lockedMetamask: true,
   userTournamentInfo: undefined,
   tokenSymbol: 'ETH',
+  tokenBalanceIsWrappedEther: false,
   acceptedTOS: false,
   hasVerified: false,
 }

--- a/src/containers/HeaderContainer/store/selectors.js
+++ b/src/containers/HeaderContainer/store/selectors.js
@@ -1,6 +1,7 @@
 import {
   getCurrentAccount,
   getCurrentNetwork,
+  getCurrentBalance,
   getActiveProvider,
   checkWalletConnection,
   hasAcceptedTermsAndConditions,
@@ -48,9 +49,11 @@ export default (state) => {
     showGameGuide: isFeatureEnabled('gameGuide'),
     gameGuideType: gameGuideConfig.type,
     gameGuideURL: gameGuideConfig.url,
+    etherBalance: getCurrentBalance(state),
     tokenAddress: collateralToken.address,
     tokenBalance: collateralToken.balance,
     tokenSymbol: collateralToken.symbol,
+    tokenBalanceIsWrappedEther: collateralToken.isWrappedEther,
     acceptedTOS: hasAcceptedTermsAndConditions(state),
     hasVerified: isVerified(state),
   }

--- a/src/integrations/store/selectors/index.js
+++ b/src/integrations/store/selectors/index.js
@@ -2,6 +2,7 @@ import { WALLET_PROVIDER } from 'integrations/constants'
 import { List } from 'immutable'
 import { getConfiguration, getFeatureConfig, isFeatureEnabled } from 'utils/features'
 import { normalizeHex } from 'utils/helpers'
+import { getCollateralToken } from 'store/selectors/blockchain'
 
 const config = getConfiguration()
 
@@ -11,6 +12,7 @@ const isTournament = isFeatureEnabled('tournament')
 const requireRegistration = isFeatureEnabled('registration')
 const requireVerification = isFeatureEnabled('verification')
 const verificationConfig = getFeatureConfig('verification')
+const collateralTokenConfig = getFeatureConfig('collateralToken')
 
 const legalDocuments = legalComplianceConfig.documents || []
 

--- a/src/integrations/store/selectors/index.js
+++ b/src/integrations/store/selectors/index.js
@@ -2,7 +2,6 @@ import { WALLET_PROVIDER } from 'integrations/constants'
 import { List } from 'immutable'
 import { getConfiguration, getFeatureConfig, isFeatureEnabled } from 'utils/features'
 import { normalizeHex } from 'utils/helpers'
-import { getCollateralToken } from 'store/selectors/blockchain'
 
 const config = getConfiguration()
 
@@ -12,7 +11,6 @@ const isTournament = isFeatureEnabled('tournament')
 const requireRegistration = isFeatureEnabled('registration')
 const requireVerification = isFeatureEnabled('verification')
 const verificationConfig = getFeatureConfig('verification')
-const collateralTokenConfig = getFeatureConfig('collateralToken')
 
 const legalDocuments = legalComplianceConfig.documents || []
 
@@ -145,7 +143,8 @@ export const isConnectedToCorrectNetwork = (state) => {
 
 export const checkWalletConnection = (state) => {
   const provider = getActiveProvider(state)
-  const termsNotRequiredOrAccepted = hasAcceptedTermsAndConditions(state) || (isTournament && !!getRegisteredMainnetAddress(state))
+  const termsNotRequiredOrAccepted = hasAcceptedTermsAndConditions(state)
+    || (isTournament && !!getRegisteredMainnetAddress(state))
 
   if (termsNotRequiredOrAccepted && provider?.account) {
     return true
@@ -154,7 +153,9 @@ export const checkWalletConnection = (state) => {
   return false
 }
 
-export const shouldOpenNetworkModal = state => isRemoteConnectionEstablished(state) && checkWalletConnection(state) && !isConnectedToCorrectNetwork(state)
+export const shouldOpenNetworkModal = state => isRemoteConnectionEstablished(state)
+  && checkWalletConnection(state)
+  && !isConnectedToCorrectNetwork(state)
 
 export const isOnWhitelist = (state) => {
   const account = getCurrentAccount(state)

--- a/src/routes/Dashboard/components/Dashboard/Metrics/index.js
+++ b/src/routes/Dashboard/components/Dashboard/Metrics/index.js
@@ -32,7 +32,7 @@ const Metrics = ({
         explanation={`${collateralToken.symbol} tokens`}
       >
         <DecimalValue value={collateralToken.balance} className={cx('metric-value')} />&nbsp;
-        <CurrencyName tokenAddress={collateralToken.address} />
+        {collateralToken.symbol}
       </Metric>
       <Metric
         isLoading={typeof predictedProfits === 'undefined'}
@@ -40,7 +40,7 @@ const Metrics = ({
         explanation="Predicted Profits"
       >
         <DecimalValue value={weiToEth(predictedProfits)} className={cx('metric-value')} />&nbsp;
-        <CurrencyName tokenAddress={collateralToken.address} />
+        {collateralToken.symbol}
       </Metric>
       {tournamentEnabled && (
         <>

--- a/src/routes/Dashboard/components/Dashboard/Metrics/index.js
+++ b/src/routes/Dashboard/components/Dashboard/Metrics/index.js
@@ -6,7 +6,6 @@ import classnames from 'classnames/bind'
 import outstandingPredictionsIcon from 'routes/Dashboard/assets/icon_outstandingPredictions.svg'
 import etherTokensIcon from 'routes/Dashboard/assets/icon_etherTokens.svg'
 
-import CurrencyName from 'components/CurrencyName'
 import DecimalValue from 'components/DecimalValue'
 import Block from 'components/layout/Block'
 import { weiToEth } from 'utils/helpers'

--- a/src/store/actions/blockchain.js
+++ b/src/store/actions/blockchain.js
@@ -108,6 +108,7 @@ export const updateCollateralToken = () => async (dispatch) => {
 
   const { source, options } = collateralTokenFromConfig
 
+
   if (source === TOKEN_SOURCE_ETH) {
     // options are optional here
     const { icon = ETH_TOKEN_ICON, symbol = 'ETH' } = options || {}
@@ -118,7 +119,9 @@ export const updateCollateralToken = () => async (dispatch) => {
       icon,
     }))
   } if (source === TOKEN_SOURCE_CONTRACT) {
-    const { contractName, symbol, icon } = options
+    const {
+      contractName, symbol, icon, isWrappedEther = false,
+    } = options
 
     if (!contractName) {
       throw new Error(
@@ -154,14 +157,18 @@ export const updateCollateralToken = () => async (dispatch) => {
       address: hexWithoutPrefix(contractInstance.address),
       symbol: tokenSymbol,
       icon: icon || ETH_TOKEN_ICON,
+      isWrappedEther,
     }))
   } if (source === TOKEN_SOURCE_ADDRESS) {
-    const { address, symbol, icon } = options
+    const {
+      address, symbol, icon, isWrappedEther = false,
+    } = options
     return dispatch(setCollateralToken({
       source: TOKEN_SOURCE_ADDRESS,
       address: hexWithoutPrefix(address),
       symbol,
       icon,
+      isWrappedEther,
     }))
   }
 

--- a/src/store/actions/blockchain.js
+++ b/src/store/actions/blockchain.js
@@ -220,4 +220,6 @@ export const initGnosis = () => async (dispatch, getState) => {
       return dispatch(setConnectionStatus({ connected: false }))
     }
   }
+
+  return undefined
 }

--- a/src/store/reducers/blockchain.js
+++ b/src/store/reducers/blockchain.js
@@ -29,7 +29,7 @@ const reducer = handleActions(
     [setTokenBalance]: (state, { payload: { tokenAddress, tokenBalance } }) => state.setIn(['tokenBalances', tokenAddress], tokenBalance),
     [setCollateralToken]: (state, {
       payload: {
-        address, symbol, icon, source,
+        address, symbol, icon, source, isWrappedEther,
       },
     }) => state.set(
       'collateralToken',
@@ -38,6 +38,7 @@ const reducer = handleActions(
         symbol,
         icon,
         source,
+        isWrappedEther,
       }),
     ),
   },

--- a/src/store/selectors/blockchain.js
+++ b/src/store/selectors/blockchain.js
@@ -35,22 +35,36 @@ export const getTokenSymbol = (state, tokenAddress) => state.blockchain.getIn(['
 export const getCollateralToken = (state) => {
   const collateralToken = state.blockchain.get('collateralToken').toJS()
 
-  const { source, address } = collateralToken
+  const { source, address, isWrappedEther } = collateralToken
 
   if (source === TOKEN_SOURCE_ADDRESS) {
     // hardcoded address for collateralToken contract
     if (address) {
+      let tokenBalance = weiToEth(getTokenAmount(state, normalizeHex(address)))
+
+      if (isWrappedEther) {
+        const etherBalance = getCurrentBalance(state)
+        tokenBalance += etherBalance
+      }
+
       return {
         ...collateralToken,
-        balance: weiToEth(getTokenAmount(state, normalizeHex(address))),
+        balance: tokenBalance,
       }
     }
   } else if (source === TOKEN_SOURCE_CONTRACT) {
     // might need to wait until address becomes available
     if (address) {
+      let tokenBalance = weiToEth(getTokenAmount(state, normalizeHex(address)))
+
+      if (isWrappedEther) {
+        const etherBalance = getCurrentBalance(state)
+        tokenBalance += etherBalance
+      }
+
       return {
         ...collateralToken,
-        balance: weiToEth(getTokenAmount(state, normalizeHex(address))),
+        balance: tokenBalance,
       }
     }
   } else if (source === TOKEN_SOURCE_ETH) {


### PR DESCRIPTION
### Description
* Implements a way to sum WETH and ETH in case configs `collateralToken.options.isWrappedEther` is set to true. Defaults to false.

### Which Tickets does my PR fix? (Put in title too)
* Fixes #510

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* Less confusion about WETH

### Which Steps did I take to verify my PR?

*Have WETH*
* Displays WETH + ETH

*Have ETH*
* Displays ETH + WETH

*Disable Config Entry for `isWrappedEther`*
* Everything as before

### Background Information
![image](https://user-images.githubusercontent.com/969493/46609795-41918480-cb09-11e8-96ab-a1d733ebe5aa.png)


### Configuration Entries
`/fallback.config`
```
{
  ...
  "collateralToken":  {
    "source": "contract",
    "options": {
      "contractName": "etherToken",
      "isWrappedEther": true,
      "symbol": "ETH",
      "icon": "/assets/img/icons/icon_etherTokens.svg"
    }
  },
```