### PR TITLE
Feature #517: Moved Filter above Marketlist on smaller screens

### DIFF
--- a/src/routes/MarketList/components/Filter/Filter.scss
+++ b/src/routes/MarketList/components/Filter/Filter.scss
@@ -2,4 +2,8 @@
   input {
     font-size: 12px;
   }
+
+  label {
+    margin: 12px 0;
+  }
 }

--- a/src/routes/MarketList/components/MarketList/index.js
+++ b/src/routes/MarketList/components/MarketList/index.js
@@ -27,11 +27,11 @@ class MarketList extends Component {
           endingSoon={endingSoonMarkets}
         />
         <MarketOverview>
-          <div className="col-md-9">
-            { markets ? <Markets markets={markets} userAccount={userAccount} viewMarket={viewMarket} /> : <NoMarkets /> }
-          </div>
-          <div className="col-md-3">
+          <div className="col-md-3 col-md-push-9">
             <Filter userAccount={userAccount} />
+          </div>
+          <div className="col-md-9 col-md-pull-3">
+            { markets ? <Markets markets={markets} userAccount={userAccount} viewMarket={viewMarket} /> : <NoMarkets /> }
           </div>
         </MarketOverview>
       </div>


### PR DESCRIPTION
### Description
* Using Bootstraps `col-<size>-<push/pull>-<size>` I moved the filter underneath one another on smaller screens.

### Which Tickets does my PR fix? (Put in title too)
* Resolves #517 

### Which PRs are linked to my PR?
* /

### Which side effects could my PR have?
* /

### Which Steps did I take to verify my PR?

*Small Screen (Resized Chrome/MacOSX)*
* Filter above Marketlist

*Big Screen (Fullscreen Chrome/MacOSX)*
* Filter on previous position

### Background Information
* Used this method: https://getbootstrap.com/docs/3.3/css/#grid-column-ordering

### Configuration Entries
* /